### PR TITLE
feat: add experience timeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import About from "./components/about";
 import Contacts from "./components/contacts";
+import Experience from "./components/experience";
 import Hero from "./components/hero";
 import Projects from "./components/projects";
 import Techs from "./components/techs";
@@ -9,6 +10,7 @@ function App() {
 		<div className="min-h-screen bg-linear-150 from-zinc-900 from-25% to-zinc-700 to-85% text-white">
 			<Hero />
 			<About />
+			<Experience />
 			<Techs />
 			<Projects />
 			<Contacts />

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -1,0 +1,181 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Badge } from "./ui/badge";
+import { Building2, CheckCircle2, MapPin } from "lucide-react";
+
+type ExperienceMetric = {
+	value: string;
+	label: string;
+};
+
+type ExperiencePeriod = {
+	start: string;
+	end: string | null;
+};
+
+type ExperienceItem = {
+	id: string;
+	company: string;
+	role: string;
+	badge: string;
+	period: ExperiencePeriod;
+	location: string;
+	context: string;
+	achievements: string[];
+	metrics: ExperienceMetric[];
+	stack: string[];
+};
+
+const Experience = () => {
+	const { t, i18n } = useTranslation();
+	const timelineTranslation = t("experience.timeline", {
+		returnObjects: true,
+	}) as ExperienceItem[] | Record<string, ExperienceItem>;
+	const timeline = (
+		Array.isArray(timelineTranslation)
+			? timelineTranslation
+			: Object.values(timelineTranslation ?? {})
+	) as ExperienceItem[];
+	const locale = i18n.language?.startsWith("pt") ? "pt-BR" : "en-US";
+	const presentLabel = t("experience.present");
+	const dateFormatter = useMemo(
+		() =>
+			new Intl.DateTimeFormat(locale, {
+				month: "short",
+				year: "numeric",
+			}),
+		[locale],
+	);
+	const parseDate = (value: string) => {
+		const [day, month, year] = value.split("/").map(Number);
+		return new Date(year, (month ?? 1) - 1, day ?? 1);
+	};
+	const formatPeriod = (period: ExperiencePeriod) => {
+		const start = dateFormatter.format(parseDate(period.start));
+		const end = period.end
+			? dateFormatter.format(parseDate(period.end))
+			: presentLabel;
+		return `${start} – ${end}`;
+	};
+	const sortedTimeline = [...timeline].sort((a, b) => {
+		const endA = a.period.end
+			? parseDate(a.period.end).getTime()
+			: Number.MAX_SAFE_INTEGER;
+		const endB = b.period.end
+			? parseDate(b.period.end).getTime()
+			: Number.MAX_SAFE_INTEGER;
+		if (endA !== endB) {
+			return endB - endA;
+		}
+		return (
+			parseDate(b.period.start).getTime() -
+			parseDate(a.period.start).getTime()
+		);
+	});
+
+	return (
+		<section
+			className="mx-auto w-full px-4 py-12 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			id="experience"
+		>
+			<div className="space-y-4 text-center">
+				<p className="text-xs font-semibold uppercase tracking-[0.6rem] text-blue-300">
+					{t("experience.kicker")}
+				</p>
+				<h2 className="text-3xl font-bold md:text-4xl">
+					{t("experience.title")}
+				</h2>
+				<p className="text-base text-zinc-300 md:text-lg">
+					{t("experience.subtitle")}
+				</p>
+			</div>
+
+			<div className="relative mt-12">
+				<span
+					aria-hidden
+					className="absolute left-4 top-0 h-full w-px bg-white/10"
+				/>
+				<div className="space-y-8">
+					{sortedTimeline.map((item) => (
+						<article
+							key={item.id}
+							className="relative rounded-3xl border border-white/10 bg-white/5 p-6 pl-10 shadow-xl shadow-black/20 backdrop-blur"
+						>
+							<span className="absolute left-4 top-10 flex h-6 w-6 -translate-x-1/2 items-center justify-center rounded-full border-2 border-blue-500 bg-zinc-900">
+								<span className="h-2 w-2 rounded-full bg-blue-400" />
+							</span>
+
+							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+								<div className="flex flex-wrap items-center gap-3">
+									<Badge className="border-blue-500/40 bg-blue-500/10 text-xs uppercase tracking-wider text-blue-200">
+										{item.badge}
+									</Badge>
+									<Badge variant="outline" className="border-white/30 text-white">
+										{item.company}
+									</Badge>
+									<span className="flex items-center gap-1 text-sm text-zinc-300">
+										<Building2 className="size-4" />
+										{item.role}
+									</span>
+									</div>
+									<div className="flex flex-wrap items-center gap-3 text-sm text-zinc-400">
+										<span>{formatPeriod(item.period)}</span>
+										<span className="flex items-center gap-1 text-zinc-400">
+											<MapPin className="size-4" />
+											{item.location}
+										</span>
+									</div>
+							</div>
+
+							<p className="mt-4 text-base text-zinc-200">
+								{item.context}
+							</p>
+
+							<ul className="mt-6 space-y-2 text-sm text-zinc-100">
+								{item.achievements.map((achievement) => (
+									<li
+										key={`${item.id}-${achievement}`}
+										className="flex items-start gap-2"
+									>
+										<CheckCircle2 className="mt-0.5 size-4 text-emerald-400" />
+										<span>{achievement}</span>
+									</li>
+								))}
+							</ul>
+
+							<div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+								{item.metrics.map((metric) => (
+									<div
+										key={`${item.id}-${metric.label}`}
+										className="rounded-2xl border border-white/10 bg-black/30 p-4 text-center"
+									>
+										<p className="text-3xl font-bold text-blue-300">
+											{metric.value}
+										</p>
+										<p className="text-xs uppercase tracking-[0.3rem] text-zinc-400">
+											{metric.label}
+										</p>
+									</div>
+								))}
+							</div>
+
+							<div className="mt-6 flex flex-wrap gap-2">
+								{item.stack.map((tech) => (
+									<Badge
+										key={`${item.id}-${tech}`}
+										variant="outline"
+										className="border-white/20 bg-white/5 text-xs text-zinc-100"
+									>
+										{tech}
+									</Badge>
+								))}
+							</div>
+						</article>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+};
+
+export default Experience;

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -20,6 +20,12 @@ const Navbar = () => {
 							{t("navbar.about")}
 						</a>
 						<a
+							href="#experience"
+							className="transition-colors hover:text-blue-500"
+						>
+							{t("navbar.experience")}
+						</a>
+						<a
 							href="#projects"
 							className="transition-colors hover:text-blue-500"
 						>
@@ -55,6 +61,12 @@ const Navbar = () => {
 									className="hover:text-blue-500"
 								>
 									{t("navbar.about")}
+								</a>
+								<a
+									href="#experience"
+									className="hover:text-blue-500"
+								>
+									{t("navbar.experience")}
 								</a>
 								<a
 									href="#projects"

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -2,6 +2,7 @@
 	"navbar": {
 		"language": "Language",
 		"about": "About",
+		"experience": "Experience",
 		"projects": "Projects",
 		"contact": "Contact"
 	},
@@ -32,6 +33,206 @@
 			"second": "Away from the keyboard I'm passionate about sports (mainly volleyball 🏐), music (from sertanejo to Bruno Mars 🎵), playing guitar and good conversations. I believe technology is a bridge, and my goal is to build paths that connect data, people and real results."
 		},
 		"imageAlt": "About section illustration"
+	},
+	"experience": {
+		"kicker": "Trajectory",
+		"title": "Experience that builds a narrative before the stack",
+		"subtitle": "Each chapter mixes leadership, delivery and data reliability so the technical stack makes sense once you arrive there.",
+		"present": "Present",
+		"timeline": [
+			{
+				"id": "datahub-2025",
+				"company": "Datahub",
+				"role": "Data Engineer",
+				"badge": "Resilience & scale",
+				"period": {
+					"start": "01/06/2025",
+					"end": "31/10/2025"
+				},
+				"location": "Remote · Brazil",
+				"context": "Modernized ingestion and transformation workloads across Datahub's Apache Airflow estate serving fintech clients.",
+				"achievements": [
+					"Refreshed Apache Airflow DAGs with modular patterns, versioning and engineering best practices.",
+					"Introduced multithreading to critical routines, accelerating ingestion and transformation throughput.",
+					"Cut more than 10 hours from a 1M-record batch while reinforcing observability, structured logging and security."
+				],
+				"metrics": [
+					{
+						"value": "-10h",
+						"label": "processing time"
+					},
+					{
+						"value": "4",
+						"label": "critical DAGs revamped"
+					},
+					{
+						"value": "100%",
+						"label": "governance guardrails"
+					}
+				],
+				"stack": ["Apache Airflow", "Python", "PostgreSQL", "GCP"]
+			},
+			{
+				"id": "avod-2024",
+				"company": "Avod Tech",
+				"role": "Data Engineer",
+				"badge": "Modern Data Stack",
+				"period": {
+					"start": "01/10/2024",
+					"end": "31/03/2025"
+				},
+				"location": "Remote · São Paulo, Brazil",
+				"context": "Designed and implemented the Modern Data Stack combining ingestion, modeling and governance for Avod Tech.",
+				"achievements": [
+					"Architected ingestion flows with Airflow, Airbyte and dbt orchestrating the semantic layer on BigQuery.",
+					"Reduced ingestion time by 50% with scalable pipelines and operational standards.",
+					"Led the migration from PostgreSQL workloads to cloud data lakes while securing governance and accessibility."
+				],
+				"metrics": [
+					{
+						"value": "-50%",
+						"label": "ingestion time"
+					},
+					{
+						"value": "4",
+						"label": "Modern Stack pillars"
+					},
+					{
+						"value": "100%",
+						"label": "governance coverage"
+					}
+				],
+				"stack": ["Airflow", "Airbyte", "dbt", "BigQuery", "PostgreSQL"]
+			},
+			{
+				"id": "ioasys-2023",
+				"company": "ioasys · Suvinil",
+				"role": "Software Analyst",
+				"badge": "Product acceleration",
+				"period": {
+					"start": "01/11/2023",
+					"end": "31/07/2024"
+				},
+				"location": "Remote · São Paulo, Brazil",
+				"context": "Acted on the Suvinil project sustaining backend (Node.js, AWS Lambda, PostgreSQL) and frontend (Next.js) stacks.",
+				"achievements": [
+					"Maintained and evolved Node.js + AWS Lambda services that powered Suvinil's B2B experiences.",
+					"Sustained the Next.js frontend while resolving mission-critical incidents.",
+					"Standardized technical documentation and onboarding playbooks, trimming ramp-up time."
+				],
+				"metrics": [
+					{
+						"value": "+10%",
+						"label": "production stability"
+					},
+					{
+						"value": "-30%",
+						"label": "onboarding time"
+					},
+					{
+						"value": "2",
+						"label": "platforms shipped"
+					}
+				],
+				"stack": ["Node.js", "AWS Lambda", "PostgreSQL", "Next.js", "Scrum"]
+			},
+			{
+				"id": "goflux-2021",
+				"company": "GoFlux",
+				"role": "Tech Lead · Fullstack Developer",
+				"badge": "Logistics marketplace",
+				"period": {
+					"start": "01/08/2021",
+					"end": "28/02/2023"
+				},
+				"location": "Remote · São Paulo, Brazil",
+				"context": "Led the logistics squad delivering freight negotiation, marketplace and quoting products.",
+				"achievements": [
+					"Managed a squad with seven developers plus UX and QA, setting rituals and delivery cadence.",
+					"Built scalable NestJS APIs and Golang services powering freight, negotiation and pricing flows.",
+					"Defined architecture, code review practices and clean code standards adopted across the team."
+				],
+				"metrics": [
+					{
+						"value": "9",
+						"label": "people led"
+					},
+					{
+						"value": "2",
+						"label": "core stacks (NestJS & Go)"
+					},
+					{
+						"value": "3",
+						"label": "logistics domains"
+					}
+				],
+				"stack": ["NestJS", "Node.js", "Golang", "Fiber", "AWS"]
+			},
+			{
+				"id": "w7m-2020",
+				"company": "W7M",
+				"role": "Fullstack Web Developer",
+				"badge": "Adsense platform",
+				"period": {
+					"start": "01/07/2020",
+					"end": "31/08/2021"
+				},
+				"location": "Remote · Brazil",
+				"context": "Built a live-stream Adsense management platform used by content creators.",
+				"achievements": [
+					"Developed the solution with Laravel, Node.js/Vue.js and MySQL.",
+					"Optimized ad management flows that improved monetization for streamers.",
+					"Delivered features in a Kanban workflow focused on continuous delivery."
+				],
+				"metrics": [
+					{
+						"value": "1",
+						"label": "ads platform shipped"
+					},
+					{
+						"value": "3",
+						"label": "core stacks"
+					},
+					{
+						"value": "Kanban",
+						"label": "delivery model"
+					}
+				],
+				"stack": ["Laravel", "Node.js", "Vue.js", "MySQL"]
+			},
+			{
+				"id": "seiren-2019",
+				"company": "Seiren do Brasil",
+				"role": "Web Systems Developer",
+				"badge": "Factory systems",
+				"period": {
+					"start": "01/01/2019",
+					"end": "31/07/2020"
+				},
+				"location": "On-site · Sorocaba, Brazil",
+				"context": "Developed backend services supporting the factory operation and systems integration.",
+				"achievements": [
+					"Built backend services with .NET and SOAP webservices for manufacturing systems.",
+					"Ensured integrations between factory equipment and corporate systems remained reliable.",
+					"Provided technical support and onboarding for new developers."
+				],
+				"metrics": [
+					{
+						"value": ".NET",
+						"label": "core stack"
+					},
+					{
+						"value": "SOAP",
+						"label": "integrations"
+					},
+					{
+						"value": "Onboarding",
+						"label": "new devs mentored"
+					}
+				],
+				"stack": [".NET", "SOAP", "SQL Server"]
+			}
+		]
 	},
 	"techs": {
 		"stats": {

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -2,6 +2,7 @@
 	"navbar": {
 		"language": "Idioma",
 		"about": "Sobre",
+		"experience": "Experiências",
 		"projects": "Projetos",
 		"contact": "Contato"
 	},
@@ -31,6 +32,206 @@
 			"second": "Fora do teclado, sou apaixonado por esportes (vôlei principalmente 🏐), música (de sertanejo a Bruno Mars 🎵), violão e boas conversas. Acredito que a tecnologia é uma ponte e meu objetivo é construir caminhos que conectem dados, pessoas e resultados reais."
 		},
 		"imageAlt": "Imagem da seção sobre"
+	},
+	"experience": {
+		"kicker": "Trajetória",
+		"title": "Experiências que constroem narrativa antes das stacks",
+		"subtitle": "Cada fase mistura liderança, entrega e confiabilidade em dados para que o mergulho técnico faça sentido.",
+		"present": "Atualmente",
+		"timeline": [
+			{
+				"id": "datahub-2025",
+				"company": "Datahub",
+				"role": "Engenheiro de Dados",
+				"badge": "Resiliência & escala",
+				"period": {
+					"start": "01/06/2025",
+					"end": "31/10/2025"
+				},
+				"location": "Remoto · Brasil",
+				"context": "Modernizei fluxos de ingestão e transformação no ecossistema Apache Airflow da Datahub para clientes fintech.",
+				"achievements": [
+					"Atualizei DAGs no Apache Airflow aplicando modularização, versionamento e boas práticas.",
+					"Implementei multithreading em rotinas críticas, acelerando a ingestão e transformação.",
+					"Reduzi mais de 10h em uma carga de 1M de registros e fortaleci observabilidade, logging estruturado e segurança."
+				],
+				"metrics": [
+					{
+						"value": "-10h",
+						"label": "tempo de processamento"
+					},
+					{
+						"value": "4",
+						"label": "DAGs críticas revistas"
+					},
+					{
+						"value": "100%",
+						"label": "governança reforçada"
+					}
+				],
+				"stack": ["Apache Airflow", "Python", "PostgreSQL", "GCP"]
+			},
+			{
+				"id": "avod-2024",
+				"company": "Avod Tech",
+				"role": "Engenheiro de Dados",
+				"badge": "Modern Data Stack",
+				"period": {
+					"start": "01/10/2024",
+					"end": "31/03/2025"
+				},
+				"location": "Remoto · São Paulo, Brasil",
+				"context": "Desenhei e implementei a Modern Data Stack combinando ingestão, modelagem e governança na Avod Tech.",
+				"achievements": [
+					"Estruturei ingestões com Airflow, Airbyte e dbt orquestrando a camada semântica no BigQuery.",
+					"Reduzi em 50% o tempo de ingestão com pipelines escaláveis e padrões operacionais.",
+					"Liderei a migração de cargas PostgreSQL para data lakes em nuvem, garantindo governança e acessibilidade."
+				],
+				"metrics": [
+					{
+						"value": "-50%",
+						"label": "tempo de ingestão"
+					},
+					{
+						"value": "4",
+						"label": "pilares da MDS"
+					},
+					{
+						"value": "100%",
+						"label": "cobertura de governança"
+					}
+				],
+				"stack": ["Airflow", "Airbyte", "dbt", "BigQuery", "PostgreSQL"]
+			},
+			{
+				"id": "ioasys-2023",
+				"company": "ioasys · Suvinil",
+				"role": "Analista de Software",
+				"badge": "Aceleração de produto",
+				"period": {
+					"start": "01/11/2023",
+					"end": "31/07/2024"
+				},
+				"location": "Remoto · São Paulo, Brasil",
+				"context": "Atuei no projeto Suvinil sustentando backend (Node.js, AWS Lambda, PostgreSQL) e frontend (Next.js).",
+				"achievements": [
+					"Mantive e evoluí serviços em Node.js + AWS Lambda que suportavam o B2B da Suvinil.",
+					"Dei sustentação ao frontend em Next.js resolvendo incidentes críticos.",
+					"Padronizei documentação técnica e playbooks de onboarding, reduzindo ramp-up."
+				],
+				"metrics": [
+					{
+						"value": "+10%",
+						"label": "estabilidade em produção"
+					},
+					{
+						"value": "-30%",
+						"label": "tempo de onboarding"
+					},
+					{
+						"value": "2",
+						"label": "plataformas sustentadas"
+					}
+				],
+				"stack": ["Node.js", "AWS Lambda", "PostgreSQL", "Next.js", "Scrum"]
+			},
+			{
+				"id": "goflux-2021",
+				"company": "GoFlux",
+				"role": "Líder técnico · Fullstack",
+				"badge": "Marketplace logístico",
+				"period": {
+					"start": "01/08/2021",
+					"end": "28/02/2023"
+				},
+				"location": "Remoto · São Paulo, Brasil",
+				"context": "Liderei a squad logística entregando produtos de frete, negociação e marketplace.",
+				"achievements": [
+					"Gerenciei uma squad com sete devs, além de UX e QA, definindo rituais e cadência.",
+					"Construí APIs em NestJS e serviços em Golang que suportavam fluxos de frete e precificação.",
+					"Defini arquitetura, code review e padrões de clean code adotados pelo time."
+				],
+				"metrics": [
+					{
+						"value": "9",
+						"label": "pessoas lideradas"
+					},
+					{
+						"value": "2",
+						"label": "stacks principais (NestJS & Go)"
+					},
+					{
+						"value": "3",
+						"label": "domínios logísticos"
+					}
+				],
+				"stack": ["NestJS", "Node.js", "Golang", "Fiber", "AWS"]
+			},
+			{
+				"id": "w7m-2020",
+				"company": "W7M",
+				"role": "Fullstack Web Developer",
+				"badge": "Plataforma Adsense",
+				"period": {
+					"start": "01/07/2020",
+					"end": "31/08/2021"
+				},
+				"location": "Remoto · Brasil",
+				"context": "Construí plataforma de gestão Adsense para streamers e creators.",
+				"achievements": [
+					"Desenvolvi a solução com Laravel, Node.js/Vue.js e MySQL.",
+					"Otimizei fluxos de gestão de anúncios aumentando a monetização para streamers.",
+					"Entreguei funcionalidades em fluxo Kanban focado em entrega contínua."
+				],
+				"metrics": [
+					{
+						"value": "1",
+						"label": "plataforma entregue"
+					},
+					{
+						"value": "3",
+						"label": "stacks principais"
+					},
+					{
+						"value": "Kanban",
+						"label": "modelo de entrega"
+					}
+				],
+				"stack": ["Laravel", "Node.js", "Vue.js", "MySQL"]
+			},
+			{
+				"id": "seiren-2019",
+				"company": "Seiren do Brasil",
+				"role": "Desenvolvedor de Sistemas Web",
+				"badge": "Sistemas fabris",
+				"period": {
+					"start": "01/01/2019",
+					"end": "31/07/2020"
+				},
+				"location": "Presencial · Sorocaba, Brasil",
+				"context": "Desenvolvi serviços backend sustentando a operação fabril e integrações.",
+				"achievements": [
+					"Construí serviços em .NET com webservices SOAP para sistemas da fábrica.",
+					"Garantí integrações entre equipamentos e sistemas corporativos.",
+					"Prestei suporte técnico e onboarding para novos desenvolvedores."
+				],
+				"metrics": [
+					{
+						"value": ".NET",
+						"label": "stack principal"
+					},
+					{
+						"value": "SOAP",
+						"label": "integrações"
+					},
+					{
+						"value": "Onboarding",
+						"label": "novos devs apoiados"
+					}
+				],
+				"stack": [".NET", "SOAP", "SQL Server"]
+			}
+		]
 	},
 	"techs": {
 		"stats": {


### PR DESCRIPTION
- Abri a branch feature/experiencia via git flow e implementei a nova seção de Experiências, com timeline ordenada, badges, métricas e stacks (src/components/experience.tsx), integrando-a no fluxo do app e na navbar (src/App.tsx, src/components/navbar.tsx).
- Extraí os dados do cv_dados.pdf e atualizei as traduções em src/locales/en/common.json e src/locales/pt/common.json, incluindo períodos estruturados (start/end), indicador de vaga atual e narrativas completas em ambos os idiomas.
- Rodei npm run build para garantir que tudo continua compilando e fiz o commit feat: add experience timeline; o push falhou por falta de acesso à rede, então será preciso executar git push origin feature/experiencia localmente fora do sandbox.