### PR TITLE
feat: revamp hero, about, and contact experiences

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_CONTACT_FORM_ENDPOINT=https://formspree.io/f/mkgywoee

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import Experience from "./components/experience";
 import Hero from "./components/hero";
 import Projects from "./components/projects";
 import Techs from "./components/techs";
+import ScrollToTopButton from "./components/scroll-to-top-button";
+import Footer from "./components/footer";
 
 function App() {
 	return (
@@ -14,6 +16,8 @@ function App() {
 			<Techs />
 			<Projects />
 			<Contacts />
+			<Footer />
+			<ScrollToTopButton />
 		</div>
 	);
 }

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -1,8 +1,35 @@
+import { type JSX } from "react";
 import { useTranslation } from "react-i18next";
 import AboutImage from "../assets/about-us.png";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "./ui/card";
+import { Globe, Heart, Sparkles, UsersRound } from "lucide-react";
+
+type AboutCard = {
+	id: string;
+	title: string;
+	description: string;
+	items: string[];
+};
+
+const cardIcons: Record<string, JSX.Element> = {
+	values: <Sparkles className="size-5 text-blue-300" />,
+	softSkills: <UsersRound className="size-5 text-emerald-300" />,
+	hobbies: <Heart className="size-5 text-pink-300" />,
+	community: <Globe className="size-5 text-amber-300" />,
+};
 
 const About = () => {
 	const { t } = useTranslation();
+	const cardsTranslation = t("about.cards", {
+		returnObjects: true,
+	}) as Record<string, AboutCard>;
+	const cards = Object.values(cardsTranslation ?? {});
 
 	return (
 		<section
@@ -14,17 +41,50 @@ const About = () => {
 				alt={t("about.imageAlt")}
 				className="mx-auto hidden md:flex"
 			/>
-			<div className="w-full space-y-4 text-start">
-				<h3 className="text-2xl font-bold uppercase">
-					{t("about.title")}
-				</h3>
-				<p className="text-lg text-zinc-400">
-					{t("about.paragraphs.first")}
-				</p>
-				<p className="text-lg text-zinc-400">
-					{t("about.paragraphs.second")}
-				</p>
-				<div className="flex gap-4"></div>
+			<div className="w-full space-y-6 text-start">
+				<div className="space-y-2">
+					<p className="text-xs font-semibold uppercase tracking-[0.6rem] text-blue-300">
+						{t("about.kicker")}
+					</p>
+					<h3 className="text-2xl font-bold uppercase">
+						{t("about.title")}
+					</h3>
+					<p className="text-lg text-zinc-300">
+						{t("about.paragraphs.first")}
+					</p>
+				</div>
+				<div className="grid gap-4 sm:grid-cols-2">
+					{cards.map((card) => (
+						<Card
+							key={card.id}
+							className="border-white/10 bg-white/5 text-white backdrop-blur"
+						>
+							<CardHeader className="flex flex-row items-center gap-3 border-b border-white/5 pb-4">
+								<div className="flex size-11 items-center justify-center rounded-full border border-white/20 bg-white/5">
+									{cardIcons[card.id] ?? cardIcons.values}
+								</div>
+								<div>
+									<CardTitle className="text-base font-semibold uppercase tracking-wide">
+										{card.title}
+									</CardTitle>
+									<CardDescription className="text-xs text-zinc-400">
+										{card.description}
+									</CardDescription>
+								</div>
+							</CardHeader>
+							<CardContent className="space-y-2 pt-4 text-sm text-zinc-100">
+								{card.items.map((item) => (
+									<p key={`${card.id}-${item}`} className="flex items-start gap-2">
+										<span className="mt-1 size-1.5 rounded-full bg-blue-300" />
+										<span>{item}</span>
+									</p>
+								))}
+							</CardContent>
+						</Card>
+					))}
+				</div>
+
+				
 			</div>
 		</section>
 	);

--- a/src/components/contacts.tsx
+++ b/src/components/contacts.tsx
@@ -1,31 +1,292 @@
+import { useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "./ui/sheet";
+import { CalendarDays, Loader2, SendHorizontal } from "lucide-react";
+
+type ContactFormFields = {
+	name: string;
+	email: string;
+	message: string;
+};
+
+type FormStatus = "idle" | "success" | "error" | "missingEndpoint";
+
+const initialFormState: ContactFormFields = {
+	name: "",
+	email: "",
+	message: "",
+};
 
 const Contacts = () => {
 	const { t } = useTranslation();
+	const [formData, setFormData] =
+		useState<ContactFormFields>(initialFormState);
+	const [errors, setErrors] = useState<Partial<ContactFormFields>>({});
+	const [status, setStatus] = useState<FormStatus>("idle");
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const formEndpoint = import.meta.env.VITE_CONTACT_FORM_ENDPOINT;
+
+	const handleChange = (field: keyof ContactFormFields, value: string) => {
+		setFormData((prev) => ({ ...prev, [field]: value }));
+		setErrors((prev) => ({ ...prev, [field]: "" }));
+		setStatus("idle");
+	};
+
+	const validateForm = () => {
+		const newErrors: Partial<ContactFormFields> = {};
+		if (formData.name.trim().length < 2) {
+			newErrors.name = t("contacts.form.validation.name");
+		}
+		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		if (!emailRegex.test(formData.email.trim())) {
+			newErrors.email = t("contacts.form.validation.email");
+		}
+		if (formData.message.trim().length < 10) {
+			newErrors.message = t("contacts.form.validation.message");
+		}
+		return newErrors;
+	};
+
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const validationErrors = validateForm();
+		setErrors(validationErrors);
+
+		if (Object.keys(validationErrors).length > 0) {
+			return;
+		}
+
+		if (!formEndpoint) {
+			setStatus("missingEndpoint");
+			return;
+		}
+
+		setIsSubmitting(true);
+
+		try {
+			const response = await fetch(formEndpoint, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Accept: "application/json",
+				},
+				body: JSON.stringify(formData),
+			});
+
+			if (!response.ok) {
+				throw new Error("Failed to submit form");
+			}
+
+			setStatus("success");
+			setFormData(initialFormState);
+		} catch (error) {
+			console.error(error);
+			setStatus("error");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
 
 	return (
 		<section
-			className="mx-auto px-6 py-16 text-center lg:max-w-4xl xl:max-w-7xl"
+			className="mx-auto w-full px-4 py-16 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
 			id="contact"
 		>
-			<h2 className="mb-6 text-3xl font-bold">
-				{t("contacts.title")}
-			</h2>
-			<div className="flex justify-center gap-6">
-				<a href="mailto:caiolmaciell@gmail.com" target="_blank">
-					<Button variant="default">
-						{t("contacts.buttons.email")}
-					</Button>
-				</a>
-				<a
-					href="https://www.linkedin.com/in/caio-maciel"
-					target="_blank"
+			<div className="mb-10 space-y-3 text-center">
+				<h2 className="text-3xl font-bold">
+					{t("contacts.title")}
+				</h2>
+				<p className="text-base text-zinc-300">
+					{t("contacts.description")}
+				</p>
+			</div>
+
+			<div className="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
+				<form
+					onSubmit={handleSubmit}
+					className="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/20"
+					noValidate
 				>
-					<Button variant="default">
-						{t("contacts.buttons.linkedin")}
-					</Button>
-				</a>
+					<div>
+						<label className="text-sm font-semibold uppercase tracking-widest text-blue-200">
+							{t("contacts.form.name")}
+						</label>
+						<input
+							type="text"
+							name="name"
+							value={formData.name}
+							onChange={(event) =>
+								handleChange("name", event.target.value)
+							}
+							placeholder={t("contacts.form.placeholders.name")}
+							className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
+							aria-invalid={Boolean(errors.name)}
+						/>
+						{errors.name && (
+							<p className="mt-1 text-sm text-rose-300">
+								{errors.name}
+							</p>
+						)}
+					</div>
+					<div>
+						<label className="text-sm font-semibold uppercase tracking-widest text-blue-200">
+							{t("contacts.form.email")}
+						</label>
+						<input
+							type="email"
+							name="email"
+							value={formData.email}
+							onChange={(event) =>
+								handleChange("email", event.target.value)
+							}
+							placeholder={t("contacts.form.placeholders.email")}
+							className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
+							aria-invalid={Boolean(errors.email)}
+						/>
+						{errors.email && (
+							<p className="mt-1 text-sm text-rose-300">
+								{errors.email}
+							</p>
+						)}
+					</div>
+					<div>
+						<label className="text-sm font-semibold uppercase tracking-widest text-blue-200">
+							{t("contacts.form.message")}
+						</label>
+						<textarea
+							name="message"
+							value={formData.message}
+							onChange={(event) =>
+								handleChange("message", event.target.value)
+							}
+							placeholder={t(
+								"contacts.form.placeholders.message",
+							)}
+							rows={6}
+							className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
+							aria-invalid={Boolean(errors.message)}
+						/>
+						{errors.message && (
+							<p className="mt-1 text-sm text-rose-300">
+								{errors.message}
+							</p>
+						)}
+					</div>
+					<div className="space-y-3">
+						<Button
+							type="submit"
+							className="w-full justify-center rounded-lg bg-blue-500 px-6 py-3 text-base font-semibold uppercase tracking-wider text-white shadow-lg shadow-blue-500/20 hover:bg-blue-600"
+							disabled={isSubmitting}
+						>
+							{isSubmitting ? (
+								<>
+									<Loader2 className="size-4 animate-spin" />
+									<span>{t("contacts.form.submit")}</span>
+								</>
+							) : (
+								<>
+									<SendHorizontal className="size-4" />
+									<span>{t("contacts.form.submit")}</span>
+								</>
+							)}
+						</Button>
+						{status !== "idle" && (
+							<div
+								className={`rounded-lg border px-4 py-3 text-sm ${
+									status === "success"
+										? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+										: status === "missingEndpoint"
+											? "border-amber-500/40 bg-amber-500/10 text-amber-200"
+											: "border-rose-500/40 bg-rose-500/10 text-rose-200"
+								}`}
+								aria-live="polite"
+							>
+								{status === "success" &&
+									t("contacts.form.success")}
+								{status === "error" &&
+									t("contacts.form.error")}
+								{status === "missingEndpoint" &&
+									t("contacts.form.missingEndpoint")}
+							</div>
+						)}
+					</div>
+				</form>
+
+				<div className="space-y-6 rounded-2xl border border-white/10 bg-black/30 p-6 text-center lg:text-left">
+					<div className="space-y-4">
+						<p className="text-sm uppercase tracking-[0.4rem] text-blue-200">
+							{t("contacts.buttons.email")}
+						</p>
+						<div className="flex flex-col gap-3 sm:flex-row lg:flex-col">
+							<a
+								href="mailto:caiolmaciell@gmail.com"
+								target="_blank"
+								className="flex-1"
+							>
+								<Button className="w-full rounded-lg bg-white/10 text-white hover:bg-white/20">
+									{t("contacts.buttons.email")}
+								</Button>
+							</a>
+							<a
+								href="https://www.linkedin.com/in/caio-maciel"
+								target="_blank"
+								className="flex-1"
+							>
+								<Button className="w-full rounded-lg bg-white/10 text-white hover:bg-white/20">
+									{t("contacts.buttons.linkedin")}
+								</Button>
+							</a>
+						</div>
+					</div>
+					<Sheet>
+						<SheetTrigger asChild>
+							<Button
+								variant="outline"
+								className="w-full justify-center gap-2 rounded-lg border-blue-500/40 bg-blue-500/10 text-blue-100 hover:bg-blue-500/20"
+							>
+								<CalendarDays className="size-4" />
+								{t("contacts.calendly.cta")}
+							</Button>
+						</SheetTrigger>
+						<SheetContent
+							side="bottom"
+							className="flex h-[85vh] flex-col border-t border-white/10 bg-zinc-950 text-white sm:h-[70vh]"
+						>
+							<div className="overflow-y-auto px-1">
+								<SheetHeader className="text-left">
+									<SheetTitle className="text-2xl font-bold">
+										{t("contacts.calendly.title")}
+									</SheetTitle>
+									<SheetDescription className="text-base text-zinc-300">
+										{t("contacts.calendly.subtitle")}
+									</SheetDescription>
+								</SheetHeader>
+								<p className="mt-4 text-sm text-zinc-400">
+									{t("contacts.calendly.description")}
+								</p>
+								<div className="mt-6 overflow-hidden rounded-xl border border-white/10 bg-black/40">
+									<div className="relative w-full pt-[125%] sm:pt-[65%]">
+										<iframe
+											src="https://calendly.com/caiolmaciell/30min"
+											title="Calendly scheduling"
+											className="absolute inset-0 h-full w-full"
+											frameBorder="0"
+											allowFullScreen
+										/>
+									</div>
+								</div>
+							</div>
+						</SheetContent>
+					</Sheet>
+				</div>
 			</div>
 		</section>
 	);

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from "react-i18next";
+import { Award, Github, PenSquare } from "lucide-react";
+
+type FooterLink = {
+	id: string;
+	label: string;
+	href: string;
+};
+
+const footerIcons: Record<string, JSX.Element> = {
+	github: <Github className="size-4" />,
+	medium: <PenSquare className="size-4" />,
+	certifications: <Award className="size-4" />,
+};
+
+const Footer = () => {
+	const { t } = useTranslation();
+	const links = t("footer.links", {
+		returnObjects: true,
+	}) as FooterLink[];
+
+	return (
+		<footer className="mt-16 bg-black/60 text-white">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-10 text-sm text-zinc-400">
+				<div className="flex flex-wrap gap-4">
+					{links?.map((link) => (
+						<a
+							key={link.id}
+							href={link.href}
+							target="_blank"
+							className="flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-white transition hover:border-blue-400 hover:text-blue-300"
+						>
+							{footerIcons[link.id] ?? (
+								<span className="size-2 rounded-full bg-blue-300" />
+							)}
+							<span>{link.label}</span>
+						</a>
+					))}
+				</div>
+				<p className="text-xs text-zinc-500">
+					{t("footer.copy", { year: new Date().getFullYear() })}
+				</p>
+			</div>
+		</footer>
+	);
+};
+
+export default Footer;

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,17 +1,19 @@
 import HeroImage from "../assets/home-right.png";
 import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
+import { useTranslation } from "react-i18next";
+import { ArrowUpRight, Code2, Download, Github, Linkedin } from "lucide-react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
-import { useTranslation } from "react-i18next";
 import PT_DATA_CV from "../assets/files/pt/cv_dados.pdf";
 import PT_DEV_CV from "../assets/files/pt/cv_dev.pdf";
 import EN_DATA_CV from "../assets/files/en/cv_data.pdf";
 import EN_DEV_CV from "../assets/files/en/cv_dev.pdf";
+import type { MouseEvent } from "react";
 
 const Hero = () => {
 	const { t, i18n } = useTranslation();
@@ -20,9 +22,57 @@ const Hero = () => {
 	const devCv = isPT ? PT_DEV_CV : EN_DEV_CV;
 	const today = new Date();
 	const formattedDate = today.toISOString().split("T")[0];
+	const scrollToProjects = (event: MouseEvent<HTMLAnchorElement>) => {
+		event.preventDefault();
+		const target = document.querySelector<HTMLElement>("#projects");
+		if (!target) return;
+		const NAVBAR_OFFSET = 80;
+		const targetPosition =
+			target.getBoundingClientRect().top + window.scrollY - NAVBAR_OFFSET;
+		const duration = 700;
+		const start = window.scrollY;
+		const distance = targetPosition - start;
+		let startTime: number | null = null;
+		const easeInOutCubic = (t: number) =>
+			t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+		const animationStep = (currentTime: number) => {
+			if (startTime === null) startTime = currentTime;
+			const progress = Math.min(
+				(currentTime - startTime) / duration,
+				1,
+			);
+			const eased = easeInOutCubic(progress);
+			window.scrollTo({
+				top: start + distance * eased,
+			});
+			if (progress < 1) {
+				requestAnimationFrame(animationStep);
+			}
+		};
+
+		requestAnimationFrame(animationStep);
+	};
+	const socialLinks = [
+		{
+			id: "linkedin",
+			href: "https://www.linkedin.com/in/caio-maciel",
+			label: t("hero.social.linkedin"),
+			icon: <Linkedin className="size-4" />,
+		},
+		{
+			id: "github",
+			href: "https://github.com/M4ciel",
+			label: t("hero.social.github"),
+			icon: <Github className="size-4" />,
+		},
+	];
 
 	return (
-		<section className="mx-auto grid grid-cols-1 items-center gap-8 px-4 pt-24 pb-16 text-center text-white md:grid-cols-2 md:pt-32 md:pb-20 md:text-left lg:max-w-4xl lg:px-0 xl:max-w-7xl">
+		<section
+			className="mx-auto grid grid-cols-1 items-center gap-8 px-4 pt-24 pb-16 text-center text-white md:grid-cols-2 md:pt-32 md:pb-20 md:text-left lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			id="hero"
+		>
 			<div className="w-full space-y-4 text-start">
 				<div className="flex items-center gap-4">
 					<h3 className="text-2xl font-semibold uppercase">
@@ -35,34 +85,71 @@ const Hero = () => {
 					{t("hero.title")}
 				</h1>
 				<p className="text-lg">{t("hero.role")}</p>
-				<div className="flex gap-4">
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button className="cursor-pointer rounded-none bg-linear-150 from-blue-400 from-0% to-blue-600 to-100% uppercase transition-colors hover:from-white hover:to-zinc-300 hover:text-zinc-900">
-								{t("hero.downloadButton.title")}
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent>
-							<a
-								href={dataCv}
-								download={`${t("hero.downloadButton.data.file")}_${formattedDate}`}
-								target="_blank"
-							>
-								<DropdownMenuItem>
-									{t("hero.downloadButton.data.title")}
-								</DropdownMenuItem>
+				<div className="space-y-4">
+					<div className="grid gap-3 sm:grid-cols-2">
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button className="h-auto cursor-pointer rounded-lg bg-linear-150 from-blue-400 from-0% to-blue-600 to-100% px-6 py-4 text-base font-semibold uppercase tracking-wide transition hover:-translate-y-0.5 hover:shadow-lg">
+									<Download className="size-5" />
+									{t("hero.downloadButton.title")}
+									<ArrowUpRight className="size-4" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent className="min-w-56 border-white/10 bg-zinc-900 text-white">
+								<a
+									href={dataCv}
+									download={`${t("hero.downloadButton.data.file")}_${formattedDate}`}
+									target="_blank"
+									rel="noreferrer"
+								>
+									<DropdownMenuItem className="cursor-pointer">
+										{t("hero.downloadButton.data.title")}
+									</DropdownMenuItem>
+								</a>
+								<a
+									href={devCv}
+									download={`${t("hero.downloadButton.dev.file")}_${formattedDate}`}
+									target="_blank"
+									rel="noreferrer"
+								>
+									<DropdownMenuItem className="cursor-pointer">
+										{t("hero.downloadButton.dev.title")}
+									</DropdownMenuItem>
+								</a>
+							</DropdownMenuContent>
+						</DropdownMenu>
+						<Button
+							asChild
+							variant="outline"
+							className="h-auto cursor-pointer rounded-lg border-white/40 bg-white/5 px-6 py-4 text-base font-semibold uppercase tracking-wide text-white transition hover:-translate-y-0.5 hover:bg-white/10"
+						>
+							<a href="#projects" onClick={scrollToProjects}>
+								<Code2 className="size-5" />
+								{t("hero.actions.devProjects")}
+								<ArrowUpRight className="size-4" />
 							</a>
-							<a
-								href={devCv}
-								download={`${t("hero.downloadButton.dev.file")}_${formattedDate}`}
-								target="_blank"
-							>
-								<DropdownMenuItem>
-									{t("hero.downloadButton.dev.title")}
-								</DropdownMenuItem>
-							</a>
-						</DropdownMenuContent>
-					</DropdownMenu>
+						</Button>
+					</div>
+					<div className="space-y-2">
+						<p className="text-sm font-semibold uppercase tracking-[0.4rem] text-blue-300">
+							{t("hero.social.label")}
+						</p>
+						<div className="flex items-center gap-3">
+							{socialLinks.map((link) => (
+								<Button
+									key={link.id}
+									asChild
+									variant="ghost"
+									size="icon"
+									className="size-11 rounded-full border border-white/20 bg-white/5 text-white hover:border-white/60 hover:bg-white/10"
+								>
+									<a href={link.href} target="_blank" rel="noreferrer" aria-label={link.label}>
+										{link.icon}
+									</a>
+								</Button>
+							))}
+						</div>
+					</div>
 				</div>
 			</div>
 			<img src={HeroImage} alt={t("hero.altImg")} className="mx-auto" />

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,9 +2,60 @@ import { Menu } from "lucide-react";
 import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
 import { LanguageSwitcher } from "./language-switcher";
 import { useTranslation } from "react-i18next";
+import { useState, type MouseEvent } from "react";
 
 const Navbar = () => {
 	const { t } = useTranslation();
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
+	const navItems = [
+		{ id: "hero", label: t("navbar.home") },
+		{ id: "about", label: t("navbar.about") },
+		{ id: "experience", label: t("navbar.experience") },
+		{ id: "projects", label: t("navbar.projects") },
+		{ id: "contact", label: t("navbar.contact") },
+	];
+
+	const smoothScrollTo = (targetPosition: number, duration = 700) => {
+		const start = window.scrollY;
+		const distance = targetPosition - start;
+		let startTime: number | null = null;
+		const easeInOutCubic = (t: number) =>
+			t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+		const animationStep = (currentTime: number) => {
+			if (startTime === null) {
+				startTime = currentTime;
+			}
+			const progress = Math.min(
+				(currentTime - startTime) / duration,
+				1,
+			);
+			const easedProgress = easeInOutCubic(progress);
+			window.scrollTo({
+				top: start + distance * easedProgress,
+			});
+			if (progress < 1) {
+				requestAnimationFrame(animationStep);
+			}
+		};
+
+		requestAnimationFrame(animationStep);
+	};
+
+	const handleNavClick = (
+		event: MouseEvent<HTMLAnchorElement>,
+		targetId: string,
+	) => {
+		event.preventDefault();
+		const target = document.querySelector<HTMLElement>(`#${targetId}`);
+		if (!target) return;
+		const NAVBAR_OFFSET = 80;
+		const targetPosition =
+			target.getBoundingClientRect().top + window.scrollY - NAVBAR_OFFSET;
+		smoothScrollTo(targetPosition);
+		setIsMenuOpen(false);
+	};
+
 	return (
 		<nav className="fixed top-0 left-0 z-50 w-full bg-zinc-900 text-white shadow">
 			<div className="mx-auto flex items-center justify-between gap-4 px-4 py-4 lg:max-w-4xl lg:px-0 xl:max-w-7xl">
@@ -13,30 +64,16 @@ const Navbar = () => {
 				{/* Menu Desktop */}
 				<div className="hidden items-center gap-4 text-sm md:flex">
 					<div className="flex items-center space-x-6">
-						<a
-							href="#about"
-							className="transition-colors hover:text-blue-500"
-						>
-							{t("navbar.about")}
-						</a>
-						<a
-							href="#experience"
-							className="transition-colors hover:text-blue-500"
-						>
-							{t("navbar.experience")}
-						</a>
-						<a
-							href="#projects"
-							className="transition-colors hover:text-blue-500"
-						>
-							{t("navbar.projects")}
-						</a>
-						<a
-							href="#contact"
-							className="transition-colors hover:text-blue-500"
-						>
-							{t("navbar.contact")}
-						</a>
+						{navItems.map((item) => (
+							<a
+								key={item.id}
+								href={`#${item.id}`}
+								className="transition-colors hover:text-blue-500"
+								onClick={(event) => handleNavClick(event, item.id)}
+							>
+								{item.label}
+							</a>
+						))}
 					</div>
 					<LanguageSwitcher />
 				</div>
@@ -44,7 +81,7 @@ const Navbar = () => {
 				{/*Menu Mobile*/}
 				<div className="flex items-center gap-2 md:hidden">
 					<LanguageSwitcher />
-					<Sheet>
+					<Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
 						<SheetTrigger aria-label="Abrir Menu">
 							<Menu className="size-6" />
 						</SheetTrigger>
@@ -56,30 +93,16 @@ const Navbar = () => {
 								Caio Maciel
 							</span>
 							<div className="mt-8 flex flex-col space-y-4 text-sm">
-								<a
-									href="#about"
-									className="hover:text-blue-500"
-								>
-									{t("navbar.about")}
-								</a>
-								<a
-									href="#experience"
-									className="hover:text-blue-500"
-								>
-									{t("navbar.experience")}
-								</a>
-								<a
-									href="#projects"
-									className="hover:text-blue-500"
-								>
-									{t("navbar.projects")}
-								</a>
-								<a
-									href="#contact"
-									className="hover:text-blue-500"
-								>
-									{t("navbar.contact")}
-								</a>
+								{navItems.map((item) => (
+									<a
+										key={item.id}
+										href={`#${item.id}`}
+										className="hover:text-blue-500"
+										onClick={(event) => handleNavClick(event, item.id)}
+									>
+										{item.label}
+									</a>
+								))}
 								<div className="pt-4">
 									<LanguageSwitcher />
 								</div>

--- a/src/components/scroll-to-top-button.tsx
+++ b/src/components/scroll-to-top-button.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+import { ArrowUp } from "lucide-react";
+
+const ScrollToTopButton = () => {
+	const [isVisible, setIsVisible] = useState(false);
+	const [progress, setProgress] = useState(0);
+
+	useEffect(() => {
+		const handleScroll = () => {
+			const scrolled = window.scrollY;
+			const docHeight =
+				document.documentElement.scrollHeight - window.innerHeight;
+			const ratio = docHeight > 0 ? scrolled / docHeight : 0;
+			setProgress(Math.min(Math.max(ratio, 0), 1));
+			setIsVisible(scrolled > 400);
+		};
+
+		handleScroll();
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, []);
+
+	const smoothScrollToTop = () => {
+		const duration = 700;
+		const start = window.scrollY;
+		const distance = -start;
+		let startTime: number | null = null;
+		const easeInOutCubic = (t: number) =>
+			t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+		const animationStep = (currentTime: number) => {
+			if (startTime === null) startTime = currentTime;
+			const progressTime = Math.min(
+				(currentTime - startTime) / duration,
+				1,
+			);
+			const eased = easeInOutCubic(progressTime);
+			window.scrollTo({ top: start + distance * eased });
+			if (progressTime < 1) {
+				requestAnimationFrame(animationStep);
+			}
+		};
+
+		requestAnimationFrame(animationStep);
+	};
+
+	if (!isVisible) {
+		return null;
+	}
+
+	const progressDegrees = progress * 360;
+
+	return (
+		<div
+			className="fixed bottom-6 right-6 z-50 rounded-full p-[2px] shadow-lg shadow-blue-500/20 transition hover:scale-105"
+			style={{
+				background: `conic-gradient(#3b82f6 ${progressDegrees}deg, rgba(255,255,255,0.15) ${progressDegrees}deg)`,
+			}}
+		>
+			<Button
+				onClick={smoothScrollToTop}
+				className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-900 text-white transition hover:-translate-y-1 cursor-pointer"
+				aria-label="Back to top"
+				size="icon"
+			>
+				<ArrowUp className="size-5 animate-bounce" />
+			</Button>
+		</div>
+	);
+};
+
+export default ScrollToTopButton;

--- a/src/components/techs.tsx
+++ b/src/components/techs.tsx
@@ -14,6 +14,8 @@ import {
 	SheetTitle,
 	SheetTrigger,
 } from "./ui/sheet";
+import type { ReactNode } from "react";
+import type { Tech } from "../interfaces/tech";
 
 type CaseLabels = {
 	project: string;
@@ -32,6 +34,13 @@ type CaseStudy = {
 	timeframe: string;
 };
 
+type TechKpi = {
+	id: string;
+	value: string;
+	label: string;
+	description: string;
+};
+
 const Techs = () => {
 	const { techs } = useTechsHook();
 	const { t } = useTranslation();
@@ -46,6 +55,74 @@ const Techs = () => {
 	}) as CaseLabels;
 	const getCaseStudy = (caseKey: string) =>
 		t(`techs.cases.${caseKey}`, { returnObjects: true }) as CaseStudy;
+	const kpisTranslation = t("techs.kpis.items", {
+		returnObjects: true,
+	}) as TechKpi[] | Record<string, TechKpi>;
+	const kpis = Array.isArray(kpisTranslation)
+		? kpisTranslation
+		: Object.values(kpisTranslation ?? {});
+	const kpiLead = t("techs.kpis.lead");
+
+	const TechCaseSheet = ({
+		tech,
+		children,
+	}: {
+		tech: Tech;
+		children: ReactNode;
+	}) => {
+		const caseStudy = getCaseStudy(tech.caseKey);
+
+		return (
+			<Sheet>
+				<SheetTrigger asChild>{children}</SheetTrigger>
+				<SheetContent
+					side="bottom"
+					className="bg-zinc-900 text-white sm:max-w-2xl"
+				>
+					<SheetHeader className="border-b border-white/10">
+						<SheetTitle className="text-left text-xl font-bold text-white">
+							{tech.name} · {caseStudy.title}
+						</SheetTitle>
+						<SheetDescription className="text-left text-base text-zinc-300">
+							{caseStudy.summary}
+						</SheetDescription>
+					</SheetHeader>
+					<div className="grid gap-4 px-4 pb-6 pt-4 text-sm text-zinc-100">
+						<div>
+							<p className="text-xs font-bold uppercase tracking-[0.5rem] text-blue-300">
+								{caseLabels.project}
+							</p>
+							<p className="text-base">{caseStudy.project}</p>
+						</div>
+						<div className="grid gap-1 rounded-lg border border-white/10 bg-white/5 p-4 text-sm">
+							<p className="text-xs font-semibold uppercase tracking-[0.4rem] text-emerald-300">
+								{caseLabels.impact}
+							</p>
+							<p className="text-base text-white">
+								{caseStudy.impact}
+							</p>
+						</div>
+						<div className="grid gap-2 lg:grid-cols-2">
+							<div className="rounded-lg border border-white/5 bg-black/30 p-4">
+								<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-purple-300">
+									{caseLabels.metrics}
+								</p>
+								<p className="text-base">{caseStudy.metrics}</p>
+							</div>
+							<div className="rounded-lg border border-white/5 bg-black/30 p-4">
+								<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-amber-200">
+									{caseLabels.timeframe}
+								</p>
+								<p className="text-base">
+									{caseStudy.timeframe}
+								</p>
+							</div>
+						</div>
+					</div>
+				</SheetContent>
+			</Sheet>
+		);
+	};
 
 	return (
 		<TooltipProvider>
@@ -57,38 +134,58 @@ const Techs = () => {
 					<div className="grid grid-cols-3 gap-6 lg:col-span-2 lg:grid-cols-4">
 						{featuredTechs.map((tech) => (
 							<Tooltip key={tech.name}>
-								<TooltipTrigger className="flex aspect-square items-center justify-center border border-zinc-500 p-6">
-									<img
-										src={tech.image}
-										alt={tech.name}
-										className="max-h-full max-w-full object-contain"
-									/>
-								</TooltipTrigger>
+								<TechCaseSheet tech={tech}>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											className="flex aspect-square w-full items-center justify-center border border-zinc-500 bg-black/30 p-6 transition hover:-translate-y-1 hover:border-blue-400 cursor-pointer"
+											aria-label={tech.name}
+										>
+											<img
+												src={tech.image}
+												alt={tech.name}
+												className="max-h-full max-w-full object-contain"
+											/>
+										</button>
+									</TooltipTrigger>
+								</TechCaseSheet>
 								<TooltipContent>
 									<p>{tech.name}</p>
 								</TooltipContent>
 							</Tooltip>
 						))}
 					</div>
-					<div className="grid min-w-full grid-rows-2 space-y-12 rounded-md bg-zinc-600 p-6 lg:min-w-80">
-						<div className="grid grid-cols-2 items-center justify-items-center">
-							<h1 className="text-7xl font-extrabold text-blue-500">
+					<div className="grid min-w-full gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-left text-white lg:min-w-80">
+						<div className="grid grid-cols-[auto_1fr] items-center gap-4 rounded-2xl border border-white/10 bg-black/30 p-5">
+							<h1 className="text-7xl font-extrabold leading-none text-blue-400">
 								{t("techs.stats.years")}
 							</h1>
-							<h3 className="text-xl text-white">
-								{t("techs.stats.label")}
-							</h3>
+							<div>
+								<p className="text-sm font-semibold uppercase tracking-[0.4rem] text-blue-200">
+									{kpiLead}
+								</p>
+								<p className="text-xl text-white">
+									{t("techs.stats.label")}
+								</p>
+							</div>
 						</div>
-						<div className="space-y-3 text-sm text-zinc-200 lg:mt-8">
-							<p className="text-lg">
-								{t("techs.highlights.performance")}
-							</p>
-							<p className="text-lg">
-								{t("techs.highlights.collaboration")}
-							</p>
-							<p className="text-lg">
-								{t("techs.highlights.quality")}
-							</p>
+						<div className="grid gap-4">
+							{kpis.map((kpi) => (
+								<div
+									key={kpi.id}
+									className="rounded-2xl border border-white/10 bg-black/30 p-4"
+								>
+									<p className="text-4xl font-extrabold text-emerald-300">
+										{kpi.value}
+									</p>
+									<p className="text-xs font-semibold uppercase tracking-[0.4rem] text-zinc-400">
+										{kpi.label}
+									</p>
+									<p className="mt-2 text-sm text-zinc-100">
+										{kpi.description}
+									</p>
+								</div>
+							))}
 						</div>
 					</div>
 				</div>
@@ -102,76 +199,27 @@ const Techs = () => {
 						</div>
 							<div className="relative flex-1 overflow-hidden">
 								<div className="techs-marquee-track flex items-center gap-8">
-									{marqueeTechs.map((tech, index) => {
-										const caseStudy = getCaseStudy(tech.caseKey);
-
-										return (
-											<Sheet key={`${tech.name}-${index}`}>
-												<SheetTrigger asChild>
-													<button className="flex items-center gap-3 text-left text-lg text-white/90 transition hover:text-white focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900">
-														<span className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5">
-															<img
-																src={tech.image}
-																alt={tech.name}
-																className="h-8 w-8 object-contain"
-															/>
-														</span>
-														<div className="flex flex-col">
-															<span className="text-base font-semibold uppercase tracking-wide text-blue-200">
-																{tech.badge}
-															</span>
-															<span className="text-lg font-bold">
-																{tech.name}
-															</span>
-														</div>
-													</button>
-												</SheetTrigger>
-												<SheetContent
-													side="bottom"
-													className="bg-zinc-900 text-white sm:max-w-2xl"
-												>
-													<SheetHeader className="border-b border-white/10">
-														<SheetTitle className="text-left text-xl font-bold text-white">
-															{tech.name} · {caseStudy.title}
-														</SheetTitle>
-														<SheetDescription className="text-left text-base text-zinc-300">
-															{caseStudy.summary}
-														</SheetDescription>
-													</SheetHeader>
-													<div className="grid gap-4 px-4 pb-6 pt-4 text-sm text-zinc-100">
-														<div>
-															<p className="text-xs font-bold uppercase tracking-[0.5rem] text-blue-300">
-																{caseLabels.project}
-															</p>
-															<p className="text-base">{caseStudy.project}</p>
-														</div>
-														<div className="grid gap-1 rounded-lg border border-white/10 bg-white/5 p-4 text-sm">
-															<p className="text-xs font-semibold uppercase tracking-[0.4rem] text-emerald-300">
-																{caseLabels.impact}
-															</p>
-															<p className="text-base text-white">
-																{caseStudy.impact}
-															</p>
-														</div>
-														<div className="grid gap-2 lg:grid-cols-2">
-															<div className="rounded-lg border border-white/5 bg-black/30 p-4">
-																<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-purple-300">
-																	{caseLabels.metrics}
-																</p>
-																<p className="text-base">{caseStudy.metrics}</p>
-															</div>
-															<div className="rounded-lg border border-white/5 bg-black/30 p-4">
-																<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-amber-200">
-																	{caseLabels.timeframe}
-																</p>
-																<p className="text-base">{caseStudy.timeframe}</p>
-															</div>
-														</div>
-													</div>
-												</SheetContent>
-											</Sheet>
-										);
-									})}
+									{marqueeTechs.map((tech, index) => (
+										<TechCaseSheet tech={tech} key={`${tech.name}-${index}`}>
+											<button className="flex items-center gap-3 text-left text-lg text-white/90 transition hover:text-white focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 cursor-pointer">
+												<span className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5">
+													<img
+														src={tech.image}
+														alt={tech.name}
+														className="h-8 w-8 object-contain"
+													/>
+												</span>
+												<div className="flex flex-col">
+													<span className="text-base font-semibold uppercase tracking-wide text-blue-200">
+														{tech.badge}
+													</span>
+													<span className="text-lg font-bold">
+														{tech.name}
+													</span>
+												</div>
+											</button>
+										</TechCaseSheet>
+									))}
 								</div>
 							<div className="pointer-events-none absolute inset-y-0 left-0 w-20 bg-gradient-to-r from-black/70 to-transparent" />
 							<div className="pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-l from-black/70 to-transparent" />

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,10 @@
 
 @custom-variant dark (&:is(.dark *));
 
+html {
+	scroll-behavior: smooth;
+}
+
 :root {
 	font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
 	line-height: 1.5;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,5 +1,6 @@
 {
 	"navbar": {
+		"home": "Home",
 		"language": "Language",
 		"about": "About",
 		"experience": "Experience",
@@ -10,7 +11,6 @@
 		"greeting": "Hello!",
 		"title": "I'm Caio Maciel",
 		"role": "Data Engineer and FullStack Developer",
-
 		"downloadButton": {
 			"title": "Download my CV",
 			"data": {
@@ -20,17 +20,72 @@
 			"dev": {
 				"title": "Fullstack Developer CV",
 				"file": "cv-dev_caio-maciel"
-			},
-			"dataEngineer": "Data Engineer CV",
-			"fullStackDeveloper": "Fullstack Developer CV"
+			}
+		},
+		"actions": {
+			"dataCall": "Book a Data call",
+			"devProjects": "See FullStack projects"
+		},
+		"social": {
+			"label": "Connect with me",
+			"linkedin": "LinkedIn profile",
+			"github": "GitHub profile"
 		},
 		"altImg": "Hero illustration"
 	},
 	"about": {
+		"kicker": "Who I am",
 		"title": "A brief introduction about me",
 		"paragraphs": {
 			"first": "I'm Caio Maciel, a Data Engineer and FullStack Developer with over 5 years of experience building robust, scalable and performance-driven solutions. I love data, well-crafted APIs and clean architecture, and that shows up in every project I build, from pipelines with Airflow, dbt and BigQuery to modern applications in TypeScript, Go and Python.",
 			"second": "Away from the keyboard I'm passionate about sports (mainly volleyball 🏐), music (from sertanejo to Bruno Mars 🎵), playing guitar and good conversations. I believe technology is a bridge, and my goal is to build paths that connect data, people and real results."
+		},
+		"cards": {
+			"values": {
+				"id": "values",
+				"title": "Values",
+				"description": "How I steer decisions",
+				"items": [
+					"Radical transparency with stakeholders.",
+					"Impact and risk reduction guide every priority.",
+					"Reliable data first, hype later."
+				]
+			},
+			"softSkills": {
+				"id": "softSkills",
+				"title": "Soft skills",
+				"description": "Rituals that keep delivery steady",
+				"items": [
+					"I mediate between tech and business leaders.",
+					"I codify documentation and onboarding playbooks.",
+					"I keep teams calm and shipping under pressure."
+				]
+			},
+			"hobbies": {
+				"id": "hobbies",
+				"title": "Hobbies",
+				"description": "Energy outside the keyboard",
+				"items": [
+					"Volleyball and outdoor sports to reset focus.",
+					"Guitar and music to unlock creativity.",
+					"Mentoring and sharing with other devs."
+				]
+			},
+			"community": {
+				"id": "community",
+				"title": "Community impact",
+				"description": "Mentoring & volunteering",
+				"items": [
+					"Crafting talks for data and product communities.",
+					"Volunteer mentoring for juniors and career switchers.",
+					"Supporting social projects with analytics and automation."
+				]
+			}
+		},
+		"cta": "View full journey",
+		"modal": {
+			"title": "Detailed timeline",
+			"subtitle": "A walkthrough of the projects that show how I deliver value with data and software."
 		},
 		"imageAlt": "About section illustration"
 	},
@@ -246,7 +301,30 @@
 		},
 		"ticker": {
 			"label": "Core stack",
-			"hint": "Hover to pause and explore the tools I use daily."
+			"hint": "Hover to pause, then click any tech to open its case study."
+		},
+		"kpis": {
+			"lead": "Proof in numbers",
+			"items": {
+				"throughput": {
+					"id": "throughput",
+					"value": "-10h",
+					"label": "pipeline runtime",
+					"description": "Apache Airflow workloads at Datahub now finish 1M+ record batches 10h faster."
+				},
+				"costs": {
+					"id": "costs",
+					"value": "-50%",
+					"label": "ingestion window",
+					"description": "BigQuery + dbt restructuring cut ingestion runtime (and spend) by 50%."
+				},
+				"sla": {
+					"id": "sla",
+					"value": "+10%",
+					"label": "production SLA",
+					"description": "Node.js, AWS Lambda and PostgreSQL integrations for Suvinil increased uptime by 10%."
+				}
+			}
 		},
 		"caseLabels": {
 			"project": "Project",
@@ -410,9 +488,55 @@
 	},
 	"contacts": {
 		"title": "Get in touch",
+		"description": "Prefer async conversations? Drop a quick note below or use the shortcuts for an instant reply.",
 		"buttons": {
 			"email": "Email",
 			"linkedin": "LinkedIn"
+		},
+		"form": {
+			"name": "Name",
+			"email": "Email",
+			"message": "Message",
+			"placeholders": {
+				"name": "How should I call you?",
+				"email": "name@company.com",
+				"message": "Share the context, constraints and the outcome you expect."
+			},
+			"submit": "Send message",
+			"success": "Thanks! I received your message and will reply shortly.",
+			"error": "I couldn’t send this message. Please try again or use the quick links.",
+			"missingEndpoint": "Set VITE_CONTACT_FORM_ENDPOINT to enable form submissions.",
+			"validation": {
+				"name": "Please share your full name.",
+				"email": "Provide a valid email address.",
+				"message": "Let me know a bit more (10 characters minimum)."
+			}
+		},
+		"calendly": {
+			"cta": "Schedule on Calendly",
+			"title": "Pick a time",
+			"subtitle": "Book a 30-minute session to talk about data, architecture or hiring needs.",
+			"description": "Slots are synced in real time — select the window that fits you best."
 		}
+	},
+	"footer": {
+		"links": [
+			{
+				"id": "github",
+				"label": "GitHub",
+				"href": "https://github.com/M4ciel"
+			},
+			{
+				"id": "medium",
+				"label": "Medium",
+				"href": "https://medium.com/@caiomaciel"
+			},
+			{
+				"id": "certifications",
+				"label": "Certifications",
+				"href": "https://www.credly.com/users/caio-maciel"
+			}
+		],
+		"copy": "© {{year}} Caio Maciel. All rights reserved."
 	}
 }

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -1,5 +1,6 @@
 {
 	"navbar": {
+		"home": "Início",
 		"language": "Idioma",
 		"about": "Sobre",
 		"experience": "Experiências",
@@ -19,17 +20,72 @@
 			"dev": {
 				"title": "CV Desenvolvedor Fullstack",
 				"file": "cv-dev_caio-maciel"
-			},
-			"dataEngineer": "CV Engenheiro de Dados",
-			"fullStackDeveloper": "CV Desenvolvedor Fullstack"
+			}
+		},
+		"actions": {
+			"dataCall": "Agende uma call de Dados",
+			"devProjects": "Veja projetos de FullStack"
+		},
+		"social": {
+			"label": "Conecte comigo",
+			"linkedin": "Perfil no LinkedIn",
+			"github": "Perfil no GitHub"
 		},
 		"altImg": "Imagem do Hero"
 	},
 	"about": {
+		"kicker": "Quem eu sou",
 		"title": "Uma breve introdução sobre mim",
 		"paragraphs": {
 			"first": "Sou o Caio Maciel, Engenheiro de Dados e Desenvolvedor FullStack com mais de 5 anos de experiência construindo soluções robustas, escaláveis e voltadas para performance. Tenho paixão por dados, APIs bem feitas e arquitetura limpa, e isso se reflete nos projetos que desenvolvo, desde pipelines com Airflow, dbt e BigQuery até aplicações modernas em TypeScript, Go e Python.",
 			"second": "Fora do teclado, sou apaixonado por esportes (vôlei principalmente 🏐), música (de sertanejo a Bruno Mars 🎵), violão e boas conversas. Acredito que a tecnologia é uma ponte e meu objetivo é construir caminhos que conectem dados, pessoas e resultados reais."
+		},
+		"cards": {
+			"values": {
+				"id": "values",
+				"title": "Valores",
+				"description": "Como tomo decisões com clientes",
+				"items": [
+					"Transparência radical com executivos e squads.",
+					"Decisões guiadas por impacto e redução de risco.",
+					"Foco obsessivo em dados confiáveis antes do hype."
+				]
+			},
+			"softSkills": {
+				"id": "softSkills",
+				"title": "Soft skills",
+				"description": "O que segura a barra nas entregas",
+				"items": [
+					"Facilito alinhamentos entre tech e negócio.",
+					"Apoio squads com documentação e playbooks.",
+					"Mantenho ritmos sustentáveis mesmo sob pressão."
+				]
+			},
+			"hobbies": {
+				"id": "hobbies",
+				"title": "Hobbies",
+				"description": "Energia fora do teclado",
+				"items": [
+					"Vôlei e atividades ao ar livre para limpar a mente.",
+					"Violão e música para destravar criatividade.",
+					"Conversas e mentoria para outras pessoas devs."
+				]
+			},
+			"community": {
+				"id": "community",
+				"title": "Impacto na comunidade",
+				"description": "Mentorias e voluntariado",
+				"items": [
+					"Narrativas para talks em comunidades de dados e produto.",
+					"Mentoria voluntária para devs iniciantes e transições de carreira.",
+					"Projetos sociais pontuais com análise de dados e automação."
+				]
+			}
+		},
+		"cta": "Ver trajetória completa",
+		"modal": {
+			"title": "Timeline detalhada",
+			"subtitle": "Projetos e contextos que explicam como entrego valor em dados e software."
 		},
 		"imageAlt": "Imagem da seção sobre"
 	},
@@ -245,7 +301,30 @@
 		},
 		"ticker": {
 			"label": "Stack em destaque",
-			"hint": "Passe o mouse para pausar e ver todas as tecnologias."
+			"hint": "Passe o mouse para pausar e clique em qualquer tecnologia para abrir o case."
+		},
+		"kpis": {
+			"lead": "Resultados práticos",
+			"items": {
+				"throughput": {
+					"id": "throughput",
+					"value": "-10h",
+					"label": "prazos de pipeline",
+					"description": "Pipelines no Apache Airflow (Datahub) passaram a concluir cargas de 1M+ registros 10h mais rápido."
+				},
+				"costs": {
+					"id": "costs",
+					"value": "-50%",
+					"label": "janela de ingestão",
+					"description": "Reestruturação do BigQuery + dbt cortou 50% do tempo de ingestão e, com isso, o custo de execução."
+				},
+				"sla": {
+					"id": "sla",
+					"value": "+10%",
+					"label": "SLA em produção",
+					"description": "Integrando Node.js, AWS Lambda e PostgreSQL, aumentei em 10% a estabilidade em produção do projeto Suvinil."
+				}
+			}
 		},
 		"caseLabels": {
 			"project": "Projeto",
@@ -409,9 +488,55 @@
 	},
 	"contacts": {
 		"title": "Entre em contato",
+		"description": "Prefere conversar por mensagem? Preencha o formulário ou aproveite os atalhos rápidos para responder ainda hoje.",
 		"buttons": {
 			"email": "Gmail",
 			"linkedin": "LinkedIn"
+		},
+		"form": {
+			"name": "Nome",
+			"email": "E-mail",
+			"message": "Mensagem",
+			"placeholders": {
+				"name": "Como posso te chamar?",
+				"email": "nome@empresa.com",
+				"message": "Conte o contexto, desafios e objetivo do projeto."
+			},
+			"submit": "Enviar mensagem",
+			"success": "Obrigado! Recebi sua mensagem e responderei em breve.",
+			"error": "Algo deu errado ao enviar. Tente novamente ou use os canais ao lado.",
+			"missingEndpoint": "Configure a variável VITE_CONTACT_FORM_ENDPOINT para ativar o formulário.",
+			"validation": {
+				"name": "Informe seu nome completo.",
+				"email": "Informe um e-mail válido.",
+				"message": "Escreva ao menos 10 caracteres para entendermos o contexto."
+			}
+		},
+		"calendly": {
+			"cta": "Agendar no Calendly",
+			"title": "Escolha um horário",
+			"subtitle": "Reserve um slot de 30 minutos para conversarmos sobre dados, arquitetura ou vagas.",
+			"description": "Os horários são atualizados em tempo real; escolha o que fizer mais sentido para você."
 		}
+	},
+	"footer": {
+		"links": [
+			{
+				"id": "github",
+				"label": "GitHub",
+				"href": "https://github.com/M4ciel"
+			},
+			{
+				"id": "medium",
+				"label": "Medium",
+				"href": "https://medium.com/@caiomaciel"
+			},
+			{
+				"id": "certifications",
+				"label": "Certificações",
+				"href": "https://www.credly.com/users/caio-maciel"
+			}
+		],
+		"copy": "© {{year}} Caio Maciel. Todos os direitos reservados."
 	}
 }


### PR DESCRIPTION
- Hero & navegação: novo CTA duplo (download segmentado + scroll animado para projetos), social links visíveis e navegação com smooth scroll + botão flutuante “voltar ao topo”.
- Sobre & Techs: cards reformulados com quarto pilar (“Impacto na comunidade”), modal removido, grid de techs agora abre cases tanto nos destaques quanto no letreiro e copy orientando o clique.
- Contato & rodapé: formulário completo com validação + Formspree, modal Calendly scrollável, atalhos rápidos, novo footer com links externos e copyright localizado.
- Internacionalização: todos os textos/labels/validações/rodapé em pt/en mantêm paridade; .env inclui VITE_CONTACT_FORM_ENDPOINT.
- Ajustes visuais/UX extras: alinhamento do container de contato, cursor-pointer nos elementos clicáveis, animação de scroll personalizada e indicador de progresso no botão flutuante.