### PR TITLE
feat: refresh sections with glass layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,15 +9,22 @@ import Footer from "./components/footer";
 
 function App() {
 	return (
-		<div className="min-h-screen bg-linear-150 from-zinc-900 from-25% to-zinc-700 to-85% text-white">
-			<Hero />
-			<About />
-			<Experience />
-			<Techs />
-			<Projects />
-			<Contacts />
-			<Footer />
-			<ScrollToTopButton />
+		<div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute -top-32 left-0 h-96 w-96 rounded-full bg-blue-500/20 blur-[140px]" />
+				<div className="absolute top-1/2 right-0 h-[28rem] w-[28rem] -translate-y-1/2 rounded-full bg-emerald-500/20 blur-[140px]" />
+				<div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.4),_transparent_55%)]" />
+			</div>
+			<div className="relative space-y-12 pb-14 pt-8">
+				<Hero />
+				<About />
+				<Experience />
+				<Techs />
+				<Projects />
+				<Contacts />
+				<Footer />
+				<ScrollToTopButton />
+			</div>
 		</div>
 	);
 }

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -33,20 +33,24 @@ const About = () => {
 
 	return (
 		<section
-			className="mx-auto grid grid-cols-1 items-center gap-8 px-4 pt-24 pb-16 text-center text-white md:grid-cols-2 md:pt-32 md:pb-20 lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			className="relative mx-auto grid w-full grid-cols-1 items-center gap-10 px-4 pt-4 pb-16 text-white md:grid-cols-2 lg:max-w-4xl lg:px-0 xl:max-w-7xl"
 			id="about"
 		>
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute top-0 left-0 h-64 w-64 rounded-full bg-blue-500/15 blur-[120px]" />
+				<div className="absolute right-0 bottom-0 h-64 w-64 rounded-full bg-pink-400/15 blur-[120px]" />
+			</div>
 			<img
 				src={AboutImage}
 				alt={t("about.imageAlt")}
-				className="mx-auto hidden md:flex"
+				className="relative mx-auto hidden rounded-[2rem] md:flex"
 			/>
-			<div className="w-full space-y-6 text-start">
+			<div className="relative w-full space-y-6 text-start">
 				<div className="space-y-2">
-					<p className="text-xs font-semibold uppercase tracking-[0.6rem] text-blue-300">
+					<p className="text-xs font-semibold tracking-[0.6rem] text-blue-300 uppercase">
 						{t("about.kicker")}
 					</p>
-					<h3 className="text-2xl font-bold uppercase">
+					<h3 className="text-3xl font-bold uppercase">
 						{t("about.title")}
 					</h3>
 					<p className="text-lg text-zinc-300">
@@ -57,14 +61,14 @@ const About = () => {
 					{cards.map((card) => (
 						<Card
 							key={card.id}
-							className="border-white/10 bg-white/5 text-white backdrop-blur"
+							className="group border-white/10 bg-white/5 text-white shadow-xl shadow-black/20 backdrop-blur"
 						>
 							<CardHeader className="flex flex-row items-center gap-3 border-b border-white/5 pb-4">
-								<div className="flex size-11 items-center justify-center rounded-full border border-white/20 bg-white/5">
+								<div className="flex size-12 items-center justify-center rounded-2xl border border-white/10 bg-white/10 transition group-hover:border-blue-400/40 group-hover:bg-blue-500/10">
 									{cardIcons[card.id] ?? cardIcons.values}
 								</div>
 								<div>
-									<CardTitle className="text-base font-semibold uppercase tracking-wide">
+									<CardTitle className="text-base font-semibold tracking-wide uppercase">
 										{card.title}
 									</CardTitle>
 									<CardDescription className="text-xs text-zinc-400">
@@ -74,7 +78,10 @@ const About = () => {
 							</CardHeader>
 							<CardContent className="space-y-2 pt-4 text-sm text-zinc-100">
 								{card.items.map((item) => (
-									<p key={`${card.id}-${item}`} className="flex items-start gap-2">
+									<p
+										key={`${card.id}-${item}`}
+										className="flex items-start gap-2"
+									>
 										<span className="mt-1 size-1.5 rounded-full bg-blue-300" />
 										<span>{item}</span>
 									</p>
@@ -83,8 +90,6 @@ const About = () => {
 						</Card>
 					))}
 				</div>
-
-				
 			</div>
 		</section>
 	);

--- a/src/components/contacts.tsx
+++ b/src/components/contacts.tsx
@@ -97,22 +97,26 @@ const Contacts = () => {
 
 	return (
 		<section
-			className="mx-auto w-full px-4 py-16 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			className="relative mx-auto w-full px-4 pb-20 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
 			id="contact"
 		>
-			<div className="mb-10 space-y-3 text-center">
-				<h2 className="text-3xl font-bold">
-					{t("contacts.title")}
-				</h2>
-				<p className="text-base text-zinc-300">
-					{t("contacts.description")}
-				</p>
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute left-0 top-6 h-64 w-64 rounded-full bg-blue-500/15 blur-[120px]" />
+				<div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-emerald-400/15 blur-[140px]" />
 			</div>
+				<div className="relative mb-10 space-y-3 text-center">
+					<h2 className="text-3xl font-bold">
+						{t("contacts.title")}
+					</h2>
+					<p className="text-base text-zinc-300">
+						{t("contacts.description")}
+					</p>
+				</div>
 
-			<div className="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
-				<form
-					onSubmit={handleSubmit}
-					className="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/20"
+				<div className="relative grid gap-10 lg:grid-cols-[1.2fr_1fr]">
+					<form
+						onSubmit={handleSubmit}
+						className="space-y-4 rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/20 backdrop-blur"
 					noValidate
 				>
 					<div>
@@ -127,7 +131,7 @@ const Contacts = () => {
 								handleChange("name", event.target.value)
 							}
 							placeholder={t("contacts.form.placeholders.name")}
-							className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
+							className="mt-2 w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
 							aria-invalid={Boolean(errors.name)}
 						/>
 						{errors.name && (
@@ -148,7 +152,7 @@ const Contacts = () => {
 								handleChange("email", event.target.value)
 							}
 							placeholder={t("contacts.form.placeholders.email")}
-							className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
+							className="mt-2 w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
 							aria-invalid={Boolean(errors.email)}
 						/>
 						{errors.email && (
@@ -171,7 +175,7 @@ const Contacts = () => {
 								"contacts.form.placeholders.message",
 							)}
 							rows={6}
-							className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
+							className="mt-2 w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-hidden"
 							aria-invalid={Boolean(errors.message)}
 						/>
 						{errors.message && (
@@ -183,7 +187,7 @@ const Contacts = () => {
 					<div className="space-y-3">
 						<Button
 							type="submit"
-							className="w-full justify-center rounded-lg bg-blue-500 px-6 py-3 text-base font-semibold uppercase tracking-wider text-white shadow-lg shadow-blue-500/20 hover:bg-blue-600"
+							className="w-full justify-center rounded-2xl bg-blue-500/80 px-6 py-3 text-base font-semibold uppercase tracking-wider text-white shadow-lg shadow-blue-500/20 transition hover:bg-blue-500"
 							disabled={isSubmitting}
 						>
 							{isSubmitting ? (
@@ -220,7 +224,7 @@ const Contacts = () => {
 					</div>
 				</form>
 
-				<div className="space-y-6 rounded-2xl border border-white/10 bg-black/30 p-6 text-center lg:text-left">
+				<div className="space-y-6 rounded-[2rem] border border-white/10 bg-black/40 p-6 text-center shadow-xl shadow-black/30 backdrop-blur lg:text-left">
 					<div className="space-y-4">
 						<p className="text-sm uppercase tracking-[0.4rem] text-blue-200">
 							{t("contacts.buttons.email")}
@@ -231,7 +235,7 @@ const Contacts = () => {
 								target="_blank"
 								className="flex-1"
 							>
-								<Button className="w-full rounded-lg bg-white/10 text-white hover:bg-white/20">
+								<Button className="w-full rounded-2xl border border-white/10 bg-white/10 text-white hover:bg-white/20">
 									{t("contacts.buttons.email")}
 								</Button>
 							</a>
@@ -240,7 +244,7 @@ const Contacts = () => {
 								target="_blank"
 								className="flex-1"
 							>
-								<Button className="w-full rounded-lg bg-white/10 text-white hover:bg-white/20">
+								<Button className="w-full rounded-2xl border border-white/10 bg-white/10 text-white hover:bg-white/20">
 									{t("contacts.buttons.linkedin")}
 								</Button>
 							</a>
@@ -250,7 +254,7 @@ const Contacts = () => {
 						<SheetTrigger asChild>
 							<Button
 								variant="outline"
-								className="w-full justify-center gap-2 rounded-lg border-blue-500/40 bg-blue-500/10 text-blue-100 hover:bg-blue-500/20"
+								className="w-full justify-center gap-2 rounded-2xl border-blue-500/40 bg-blue-500/10 text-blue-100 hover:bg-blue-500/20"
 							>
 								<CalendarDays className="size-4" />
 								{t("contacts.calendly.cta")}
@@ -258,7 +262,7 @@ const Contacts = () => {
 						</SheetTrigger>
 						<SheetContent
 							side="bottom"
-							className="flex h-[85vh] flex-col border-t border-white/10 bg-zinc-950 text-white sm:h-[70vh]"
+							className="flex h-[85vh] flex-col border-t border-white/10 bg-slate-950/90 text-white backdrop-blur-xl sm:h-[70vh]"
 						>
 							<div className="overflow-y-auto px-1">
 								<SheetHeader className="text-left">

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -75,10 +75,14 @@ const Experience = () => {
 
 	return (
 		<section
-			className="mx-auto w-full px-4 py-12 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			className="relative mx-auto w-full px-4 pb-16 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
 			id="experience"
 		>
-			<div className="space-y-4 text-center">
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute left-10 top-0 h-64 w-64 rounded-full bg-blue-500/15 blur-[140px]" />
+				<div className="absolute bottom-0 right-10 h-64 w-64 rounded-full bg-purple-500/10 blur-[140px]" />
+			</div>
+			<div className="relative space-y-4 text-center">
 				<p className="text-xs font-semibold uppercase tracking-[0.6rem] text-blue-300">
 					{t("experience.kicker")}
 				</p>
@@ -93,85 +97,129 @@ const Experience = () => {
 			<div className="relative mt-12">
 				<span
 					aria-hidden
-					className="absolute left-4 top-0 h-full w-px bg-white/10"
+					className="absolute left-4 top-0 h-full w-px bg-white/10 lg:left-1/2 lg:-translate-x-1/2"
 				/>
-				<div className="space-y-8">
-					{sortedTimeline.map((item) => (
-						<article
-							key={item.id}
-							className="relative rounded-3xl border border-white/10 bg-white/5 p-6 pl-10 shadow-xl shadow-black/20 backdrop-blur"
-						>
-							<span className="absolute left-4 top-10 flex h-6 w-6 -translate-x-1/2 items-center justify-center rounded-full border-2 border-blue-500 bg-zinc-900">
-								<span className="h-2 w-2 rounded-full bg-blue-400" />
-							</span>
-
-							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-								<div className="flex flex-wrap items-center gap-3">
-									<Badge className="border-blue-500/40 bg-blue-500/10 text-xs uppercase tracking-wider text-blue-200">
-										{item.badge}
-									</Badge>
-									<Badge variant="outline" className="border-white/30 text-white">
-										{item.company}
-									</Badge>
-									<span className="flex items-center gap-1 text-sm text-zinc-300">
-										<Building2 className="size-4" />
-										{item.role}
-									</span>
-									</div>
-									<div className="flex flex-wrap items-center gap-3 text-sm text-zinc-400">
-										<span>{formatPeriod(item.period)}</span>
-										<span className="flex items-center gap-1 text-zinc-400">
-											<MapPin className="size-4" />
-											{item.location}
-										</span>
-									</div>
+				<div className="flex flex-col gap-10 lg:gap-16">
+					{sortedTimeline.map((item, index) => {
+						const isRightAligned = index % 2 === 0;
+						const patternElement = (
+							<div
+								aria-hidden
+								className="pointer-events-none relative h-48 w-48 overflow-hidden rounded-[2rem] border border-white/10 bg-black/40"
+							>
+								<div className="absolute inset-0 bg-[radial-gradient(circle,_rgba(59,130,246,0.15)_1px,transparent_1px)] bg-[size:16px_16px] opacity-60" />
+								<div className="absolute inset-3 rounded-[1.5rem] border border-dashed border-blue-400/30" />
+								<div className="absolute left-6 top-6 flex flex-col gap-2">
+									<span className="h-1.5 w-12 rounded-full bg-sky-400/50" />
+									<span className="h-1.5 w-16 rounded-full bg-blue-300/40" />
+									<span className="h-1.5 w-10 rounded-full bg-emerald-300/40" />
+								</div>
+								<div className="absolute right-6 top-8 grid gap-2">
+									<span className="h-2 w-2 rounded-full bg-blue-400/70" />
+									<span className="h-2 w-2 rounded-full bg-emerald-400/70" />
+									<span className="h-2 w-2 rounded-full bg-blue-200/70" />
+								</div>
+								<div className="absolute bottom-6 left-6 grid grid-cols-3 gap-2">
+									<span className="h-3 w-4 rounded-md bg-sky-400/40" />
+									<span className="h-3 w-4 rounded-md bg-blue-500/40" />
+									<span className="h-3 w-4 rounded-md bg-indigo-400/40" />
+									<span className="h-3 w-4 rounded-md bg-emerald-400/40" />
+									<span className="h-3 w-4 rounded-md bg-cyan-500/40" />
+									<span className="h-3 w-4 rounded-md bg-teal-400/40" />
+								</div>
+								<div className="absolute bottom-6 right-6 h-10 w-10 rounded-2xl border border-white/20 bg-gradient-to-br from-cyan-400/30 to-blue-600/40 opacity-70 blur-[2px]" />
 							</div>
-
-							<p className="mt-4 text-base text-zinc-200">
-								{item.context}
-							</p>
-
-							<ul className="mt-6 space-y-2 text-sm text-zinc-100">
-								{item.achievements.map((achievement) => (
-									<li
-										key={`${item.id}-${achievement}`}
-										className="flex items-start gap-2"
-									>
-										<CheckCircle2 className="mt-0.5 size-4 text-emerald-400" />
-										<span>{achievement}</span>
-									</li>
-								))}
-							</ul>
-
-							<div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-								{item.metrics.map((metric) => (
-									<div
-										key={`${item.id}-${metric.label}`}
-										className="rounded-2xl border border-white/10 bg-black/30 p-4 text-center"
-									>
-										<p className="text-3xl font-bold text-blue-300">
-											{metric.value}
-										</p>
-										<p className="text-xs uppercase tracking-[0.3rem] text-zinc-400">
-											{metric.label}
-										</p>
+						);
+						return (
+							<div
+								key={item.id}
+								className="relative flex flex-col gap-6 lg:flex-row lg:items-stretch"
+							>
+								<span className="absolute left-4 top-10 flex h-6 w-6 -translate-x-1/2 items-center justify-center rounded-full border-2 border-blue-500 bg-zinc-900 lg:left-1/2 lg:-translate-x-1/2">
+									<span className="h-2 w-2 rounded-full bg-blue-400" />
+								</span>
+								{isRightAligned && (
+									<div className="hidden lg:flex lg:w-1/2 lg:justify-end">
+										{patternElement}
 									</div>
-								))}
-							</div>
+								)}
+								<article
+									className={`relative w-full rounded-3xl border border-white/10 bg-white/5 p-6 pl-10 shadow-xl shadow-black/20 backdrop-blur lg:w-1/2 lg:p-8 ${isRightAligned ? "lg:ml-8 lg:pl-10 lg:pr-6" : "lg:mr-8 lg:pl-6 lg:pr-10"}`}
+								>
+									<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+										<div className="flex flex-wrap items-center gap-3">
+											<Badge className="border-blue-500/40 bg-blue-500/10 text-xs uppercase tracking-wider text-blue-200">
+												{item.badge}
+											</Badge>
+											<Badge variant="outline" className="border-white/30 text-white">
+												{item.company}
+											</Badge>
+											<span className="flex items-center gap-1 text-sm text-zinc-300">
+												<Building2 className="size-4" />
+												{item.role}
+											</span>
+										</div>
+										<div className="flex flex-wrap items-center gap-3 text-sm text-zinc-400">
+											<span>{formatPeriod(item.period)}</span>
+											<span className="flex items-center gap-1 text-zinc-400">
+												<MapPin className="size-4" />
+												{item.location}
+											</span>
+										</div>
+									</div>
 
-							<div className="mt-6 flex flex-wrap gap-2">
-								{item.stack.map((tech) => (
-									<Badge
-										key={`${item.id}-${tech}`}
-										variant="outline"
-										className="border-white/20 bg-white/5 text-xs text-zinc-100"
-									>
-										{tech}
-									</Badge>
-								))}
+									<p className="mt-4 text-base text-zinc-200">
+										{item.context}
+									</p>
+
+									<ul className="mt-6 space-y-2 text-sm text-zinc-100">
+										{item.achievements.map((achievement) => (
+											<li
+												key={`${item.id}-${achievement}`}
+												className="flex items-start gap-2"
+											>
+												<CheckCircle2 className="mt-0.5 size-4 text-emerald-400" />
+												<span>{achievement}</span>
+											</li>
+										))}
+									</ul>
+
+									<div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+										{item.metrics.map((metric) => (
+											<div
+												key={`${item.id}-${metric.label}`}
+												className="rounded-2xl border border-white/10 bg-black/30 p-4 text-center"
+											>
+												<p className="text-3xl font-bold text-blue-300">
+													{metric.value}
+												</p>
+												<p className="text-xs uppercase tracking-[0.3rem] text-zinc-400">
+													{metric.label}
+												</p>
+											</div>
+										))}
+									</div>
+
+									<div className="mt-6 flex flex-wrap gap-2">
+										{item.stack.map((tech) => (
+											<Badge
+												key={`${item.id}-${tech}`}
+												variant="outline"
+												className="border-white/20 bg-white/5 text-xs text-zinc-100"
+											>
+												{tech}
+											</Badge>
+										))}
+									</div>
+								</article>
+								{!isRightAligned && (
+									<div className="hidden lg:flex lg:w-1/2 lg:justify-start">
+										{patternElement}
+									</div>
+								)}
 							</div>
-						</article>
-					))}
+						);
+					})}
 				</div>
 			</div>
 		</section>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Award, Github, PenSquare } from "lucide-react";
+import { Github, Linkedin } from "lucide-react";
 import type { JSX } from "react";
 
 type FooterLink = {
@@ -10,8 +10,7 @@ type FooterLink = {
 
 const footerIcons: Record<string, JSX.Element> = {
 	github: <Github className="size-4" />,
-	medium: <PenSquare className="size-4" />,
-	certifications: <Award className="size-4" />,
+	linkedin: <Linkedin className="size-4" />,
 };
 
 const Footer = () => {
@@ -21,15 +20,15 @@ const Footer = () => {
 	}) as FooterLink[];
 
 	return (
-		<footer className="mt-16 bg-black/60 text-white">
-			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-10 text-sm text-zinc-400">
+		<footer className="text-white">
+			<div className="mx-auto mt-12 flex w-full max-w-7xl flex-col gap-6 px-6 py-10 text-sm text-zinc-400 lg:px-12">
 				<div className="flex flex-wrap gap-4">
 					{links?.map((link) => (
 						<a
 							key={link.id}
 							href={link.href}
 							target="_blank"
-							className="flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-white transition hover:border-blue-400 hover:text-blue-300"
+							className="flex items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-white transition hover:border-blue-400 hover:text-blue-300"
 						>
 							{footerIcons[link.id] ?? (
 								<span className="size-2 rounded-full bg-blue-300" />

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -38,10 +38,7 @@ const Hero = () => {
 
 		const animationStep = (currentTime: number) => {
 			if (startTime === null) startTime = currentTime;
-			const progress = Math.min(
-				(currentTime - startTime) / duration,
-				1,
-			);
+			const progress = Math.min((currentTime - startTime) / duration, 1);
 			const eased = easeInOutCubic(progress);
 			window.scrollTo({
 				top: start + distance * eased,
@@ -70,32 +67,36 @@ const Hero = () => {
 
 	return (
 		<section
-			className="mx-auto grid grid-cols-1 items-center gap-8 px-4 pt-24 pb-16 text-center text-white md:grid-cols-2 md:pt-32 md:pb-20 md:text-left lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			className="relative mx-auto grid w-full grid-cols-1 items-center gap-10 px-4 pt-28 pb-16 text-white md:grid-cols-2 lg:max-w-4xl lg:px-0 xl:max-w-7xl"
 			id="hero"
 		>
-			<div className="w-full space-y-4 text-start">
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute top-0 -right-10 h-72 w-72 rounded-full bg-blue-500/20 blur-3xl" />
+				<div className="absolute -bottom-12 left-10 h-72 w-72 rounded-full bg-emerald-400/20 blur-[140px]" />
+			</div>
+			<div className="relative w-full space-y-6 text-start">
 				<div className="flex items-center gap-4">
-					<h3 className="text-2xl font-semibold uppercase">
+					<h3 className="text-2xl font-semibold tracking-[0.35rem] text-white uppercase">
 						{t("hero.greeting")}
 					</h3>
-					<Separator className="w-full max-w-52 sm:max-w-xs lg:max-w-sm xl:max-w-md" />
+					<Separator className="w-full max-w-52 border-white/30 sm:max-w-xs lg:max-w-sm xl:max-w-md" />
 				</div>
 
-				<h1 className="text-3xl font-extrabold uppercase md:text-5xl">
+				<h1 className="text-4xl leading-tight font-extrabold uppercase md:text-5xl">
 					{t("hero.title")}
 				</h1>
-				<p className="text-lg">{t("hero.role")}</p>
+				<p className="text-lg text-zinc-300">{t("hero.role")}</p>
 				<div className="space-y-4">
 					<div className="grid gap-3 sm:grid-cols-2">
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
-								<Button className="h-auto cursor-pointer rounded-lg bg-linear-150 from-blue-400 from-0% to-blue-600 to-100% px-6 py-4 text-base font-semibold uppercase tracking-wide transition hover:-translate-y-0.5 hover:shadow-lg">
+								<Button className="h-auto cursor-pointer rounded-lg bg-linear-150 from-blue-400 from-0% to-blue-600 to-100% px-6 py-4 text-base font-semibold tracking-wide uppercase transition hover:-translate-y-0.5 hover:shadow-lg">
 									<Download className="size-5" />
 									{t("hero.downloadButton.title")}
 									<ArrowUpRight className="size-4" />
 								</Button>
 							</DropdownMenuTrigger>
-							<DropdownMenuContent className="min-w-56 border-white/10 bg-zinc-900 text-white">
+							<DropdownMenuContent className="min-w-56 rounded-2xl border border-white/10 bg-slate-950/80 text-white backdrop-blur">
 								<a
 									href={dataCv}
 									download={`${t("hero.downloadButton.data.file")}_${formattedDate}`}
@@ -121,7 +122,7 @@ const Hero = () => {
 						<Button
 							asChild
 							variant="outline"
-							className="h-auto cursor-pointer rounded-lg border-white/40 bg-white/5 px-6 py-4 text-base font-semibold uppercase tracking-wide text-white transition hover:-translate-y-0.5 hover:bg-white/10"
+							className="h-auto cursor-pointer rounded-lg border-white/40 bg-white/5 px-6 py-4 text-base font-semibold tracking-wide text-white uppercase transition hover:-translate-y-0.5 hover:bg-white/10"
 						>
 							<a href="#projects" onClick={scrollToProjects}>
 								<Code2 className="size-5" />
@@ -131,7 +132,7 @@ const Hero = () => {
 						</Button>
 					</div>
 					<div className="space-y-2">
-						<p className="text-sm font-semibold uppercase tracking-[0.4rem] text-blue-300">
+						<p className="text-sm font-semibold tracking-[0.4rem] text-blue-300 uppercase">
 							{t("hero.social.label")}
 						</p>
 						<div className="flex items-center gap-3">
@@ -141,9 +142,14 @@ const Hero = () => {
 									asChild
 									variant="ghost"
 									size="icon"
-									className="size-11 rounded-full border border-white/20 bg-white/5 text-white hover:border-white/60 hover:bg-white/10"
+									className="size-11 rounded-full border border-white/20 bg-white/5 text-white transition hover:-translate-y-0.5 hover:border-white/60 hover:bg-white/10"
 								>
-									<a href={link.href} target="_blank" rel="noreferrer" aria-label={link.label}>
+									<a
+										href={link.href}
+										target="_blank"
+										rel="noreferrer"
+										aria-label={link.label}
+									>
 										{link.icon}
 									</a>
 								</Button>
@@ -152,7 +158,16 @@ const Hero = () => {
 					</div>
 				</div>
 			</div>
-			<img src={HeroImage} alt={t("hero.altImg")} className="mx-auto" />
+			<div className="relative flex justify-center">
+				<div className="absolute inset-0 rounded-[2.5rem] border border-white/10 bg-white/5 blur-3xl" />
+				<div className="relative flex aspect-square max-w-sm items-center justify-center rounded-[2.5rem]">
+					<img
+						src={HeroImage}
+						alt={t("hero.altImg")}
+						className="mx-auto w-full object-contain"
+					/>
+				</div>
+			</div>
 		</section>
 	);
 };

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -57,7 +57,7 @@ const Navbar = () => {
 	};
 
 	return (
-		<nav className="fixed top-0 left-0 z-50 w-full bg-zinc-900 text-white shadow">
+		<nav className="fixed top-0 left-0 z-50 w-full border-b border-white/10 bg-slate-950/70 text-white backdrop-blur-xl">
 			<div className="mx-auto flex items-center justify-between gap-4 px-4 py-4 lg:max-w-4xl lg:px-0 xl:max-w-7xl">
 				<span className="text-xl font-bold">Caio Maciel</span>
 
@@ -68,7 +68,7 @@ const Navbar = () => {
 							<a
 								key={item.id}
 								href={`#${item.id}`}
-								className="transition-colors hover:text-blue-500"
+								className="text-sm font-semibold uppercase tracking-[0.25rem] text-white/70 transition hover:text-white"
 								onClick={(event) => handleNavClick(event, item.id)}
 							>
 								{item.label}
@@ -87,7 +87,7 @@ const Navbar = () => {
 						</SheetTrigger>
 						<SheetContent
 							side="left"
-							className="border-r-zinc-500/20 bg-zinc-900 px-4 text-white"
+							className="border-r border-white/10 bg-slate-950/90 px-4 text-white backdrop-blur-xl"
 						>
 							<span className="mt-8 text-xl font-bold">
 								Caio Maciel

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -12,7 +12,7 @@ import {
 	CardTitle,
 } from "./ui/card";
 import { motion, AnimatePresence } from "framer-motion";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, ArrowUpRight } from "lucide-react";
 
 const Projects = () => {
 	const {
@@ -32,186 +32,214 @@ const Projects = () => {
 
 	return (
 		<section
-			className="mx-auto w-full px-4 py-12 lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			className="relative mx-auto w-full px-4 py-12 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
 			id="projects"
 		>
-			<h2 className="mb-6 text-center text-3xl font-bold">
-				{t("projects.title")}
-			</h2>
-				<div className="mb-4 flex flex-wrap justify-center gap-4 text-sm font-semibold sm:gap-6">
-					{filters.map((categorie) => {
-						const isAll = categorie === ALL_FILTER;
-						const label = isAll
-							? t("projects.filters.all")
-							: categorie;
-					return (
-						<Button
-							key={categorie}
-							onClick={() => setFilter(categorie)}
-							className={`cursor-pointer rounded-none bg-transparent px-3 py-2 text-xs uppercase sm:text-sm ${
-								filter === categorie
-									? "border-b-2 border-blue-500 text-blue-500"
-									: "text-white hover:text-blue-500"
-							}`}
-						>
-							{label}
-						</Button>
-						);
-					})}
-				</div>
-				{lastUpdatedAt ? (
-					<p className="mb-8 text-center text-xs uppercase text-zinc-400">
-						{t("projects.state.lastUpdated", {
-							date: new Date(lastUpdatedAt).toLocaleString(),
-						})}
-					</p>
-				) : (
-					<p className="mb-8 text-center text-xs uppercase text-zinc-400">
-						{t("projects.state.loading")}
-					</p>
-				)}
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute -left-24 top-0 h-64 w-64 rounded-full bg-blue-500/20 blur-3xl" />
+				<div className="absolute bottom-0 right-0 h-64 w-64 rounded-full bg-emerald-500/20 blur-[120px]" />
+				<div className="absolute inset-x-0 top-1/3 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+			</div>
 
-				<div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-				{isLoading &&
-					skeletonItems.map((_, index) => (
-						<Card
-							key={`projects-skeleton-${index}`}
-							className="h-full border-none bg-zinc-800 text-white shadow"
-						>
-							<CardHeader className="space-y-4">
-								<Skeleton className="h-6 w-3/4 bg-zinc-700" />
-								<div className="space-y-2">
-									<Skeleton className="h-4 w-full bg-zinc-700" />
-									<Skeleton className="h-4 w-4/5 bg-zinc-700" />
-								</div>
-							</CardHeader>
-							<CardContent className="space-y-4">
-								<Skeleton className="h-4 w-24 bg-zinc-700" />
-								<div className="flex flex-wrap gap-2">
-									{Array.from({ length: 3 }).map(
-										(__, badgeIndex) => (
-											<Skeleton
-												key={`badge-${badgeIndex}`}
-												className="h-6 w-16 bg-zinc-700"
-											/>
-										),
-									)}
-								</div>
-							</CardContent>
-							<CardFooter className="flex gap-4">
-								<Skeleton className="h-4 w-24 bg-zinc-700" />
-								<Skeleton className="ml-auto h-4 w-20 bg-zinc-700" />
-							</CardFooter>
-						</Card>
-					))}
+			<div className="relative space-y-4 text-center">
+				<p className="text-xs font-semibold uppercase tracking-[0.6rem] text-blue-200">
+					{t("projects.kicker")}
+				</p>
+				<h2 className="text-3xl font-bold md:text-4xl">
+					{t("projects.title")}
+				</h2>
+				<p className="text-base text-zinc-300 md:text-lg">
+					{t("projects.subtitle")}
+				</p>
+			</div>
 
-				{isError && (
-					<div className="col-span-full">
-						<Card className="border border-red-500/40 bg-zinc-900 text-white">
-							<CardHeader className="flex flex-col gap-2 text-left">
-								<div className="flex items-center gap-2 text-red-400">
-									<AlertCircle className="size-5" />
-									<span className="text-lg font-semibold">
-										{t("projects.state.error.title")}
-									</span>
-								</div>
-								<CardDescription className="text-zinc-300">
-									{t("projects.state.error.description")}
-									{error?.message && (
-										<>
-											{" "}
-											<span className="font-semibold">
-												{error.message}
-											</span>
-										</>
-									)}
-								</CardDescription>
-							</CardHeader>
-							<CardFooter>
-								<Button onClick={() => refetch()}>
-									{t("projects.state.error.retry")}
+			<div className="relative mt-10 space-y-4">
+					<div className="flex flex-wrap justify-center gap-3 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35rem] text-zinc-300 backdrop-blur">
+						{filters.map((categorie) => {
+							const isAll = categorie === ALL_FILTER;
+							const label = isAll
+								? t("projects.filters.all")
+								: categorie;
+							const isActive = filter === categorie;
+							return (
+								<Button
+									key={categorie}
+									type="button"
+									variant="ghost"
+									size="sm"
+									onClick={() => setFilter(categorie)}
+									className={`h-auto rounded-full border px-4 py-2 text-[0.6rem] tracking-[0.3rem] transition ${
+										isActive
+											? "border-blue-400/70 bg-blue-500/10 text-white shadow-[0_0_30px_rgba(59,130,246,0.25)]"
+											: "border-transparent text-zinc-300 hover:border-white/30 hover:text-white"
+									}`}
+								>
+									{label}
 								</Button>
-							</CardFooter>
-						</Card>
+							);
+						})}
 					</div>
-				)}
+					<p className="text-center text-xs uppercase text-zinc-400">
+						{lastUpdatedAt
+							? t("projects.state.lastUpdated", {
+									date: new Date(
+										lastUpdatedAt,
+									).toLocaleString(),
+								})
+							: t("projects.state.loading")}
+					</p>
+				</div>
 
-				{!isLoading && !isError && repos.length === 0 && (
-					<div className="col-span-full">
-						<Card className="border-none bg-zinc-800 text-white shadow">
-							<CardHeader>
-								<CardTitle className="text-lg">
-									{t("projects.state.empty")}
-								</CardTitle>
-								<CardDescription className="text-sm text-zinc-300">
-									{t("projects.state.emptyDescription")}
-								</CardDescription>
-							</CardHeader>
-						</Card>
-					</div>
-				)}
+				<div className="relative mt-12">
+					<div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+						{isLoading &&
+							skeletonItems.map((_, index) => (
+								<div
+									key={`projects-skeleton-${index}`}
+									className="h-full rounded-3xl border border-white/10 bg-black/40 p-6"
+								>
+									<div className="space-y-4">
+										<Skeleton className="h-5 w-24 bg-white/10" />
+										<Skeleton className="h-6 w-3/4 bg-white/10" />
+										<div className="space-y-2">
+											<Skeleton className="h-4 w-full bg-white/5" />
+											<Skeleton className="h-4 w-4/5 bg-white/5" />
+										</div>
+										<div className="flex flex-wrap gap-2">
+											{Array.from({ length: 3 }).map(
+												(__, badgeIndex) => (
+													<Skeleton
+														key={`badge-${badgeIndex}`}
+														className="h-6 w-16 rounded-full bg-white/10"
+													/>
+												),
+											)}
+										</div>
+										<Skeleton className="h-5 w-28 bg-white/10" />
+									</div>
+								</div>
+							))}
 
-				{!isLoading && !isError && repos.length > 0 && (
-					<AnimatePresence>
-						{repos.map((repo) => (
-							<motion.div
-								key={repo.id}
-								initial={{ opacity: 0, scale: 0.95 }}
-								animate={{ opacity: 1, scale: 1 }}
-								exit={{ opacity: 0, scale: 0.95 }}
-								transition={{ duration: 0.3 }}
-							>
-								<Card className="h-full border-none bg-zinc-800 text-white shadow">
-									<CardHeader className="h-full">
-										<CardTitle className="text-xl font-semibold">
-											{repo.name}
-										</CardTitle>
-										<CardDescription className="line-clamp-3 text-sm">
-											{repo.description ??
-												t("projects.noDescription")}
+						{isError && (
+							<div className="col-span-full">
+								<Card className="border border-red-500/40 bg-black/50 p-0 text-white">
+									<CardHeader className="flex flex-col gap-3 px-6 text-left">
+										<div className="flex items-center gap-2 text-red-400">
+											<AlertCircle className="size-5" />
+											<span className="text-lg font-semibold">
+												{t("projects.state.error.title")}
+											</span>
+										</div>
+										<CardDescription className="text-zinc-300">
+											{t("projects.state.error.description")}
+											{error?.message && (
+												<>
+													{" "}
+													<span className="font-semibold">
+														{error.message}
+													</span>
+												</>
+											)}
 										</CardDescription>
 									</CardHeader>
-									<CardContent className="space-y-4 text-sm text-zinc-400">
-										<p>{repo.language}</p>
-										<div className="flex flex-wrap gap-2">
-											{repo.topics
-												?.filter(
-													(topic) => topic !== "public",
-												)
-												.map((topic) => (
-													<Badge
-														key={topic}
-														className="bg-blue-500 capitalize"
-													>
-														{topic}
-													</Badge>
-												))}
-										</div>
-									</CardContent>
-									<CardFooter>
-										<a
-											href={repo.html_url}
-											target="_blank"
-											className="inline-block text-sm text-white underline"
-										>
-											{t("projects.links.github")}
-										</a>
-										{repo.homepage && (
-											<a
-												href={repo.homepage}
-												target="_blank"
-												className="ml-auto inline-block text-sm text-blue-400 underline"
-											>
-												{t("projects.links.website")}
-											</a>
-										)}
+									<CardFooter className="border-t border-red-500/30 pt-6">
+										<Button onClick={() => refetch()}>
+											{t("projects.state.error.retry")}
+										</Button>
 									</CardFooter>
 								</Card>
-							</motion.div>
-						))}
-					</AnimatePresence>
-				)}
-			</div>
+							</div>
+						)}
+
+						{!isLoading && !isError && repos.length === 0 && (
+							<div className="col-span-full">
+								<Card className="border border-white/10 bg-black/50 p-0 text-white">
+									<CardHeader className="px-6">
+										<CardTitle className="text-lg">
+											{t("projects.state.empty")}
+										</CardTitle>
+										<CardDescription className="text-sm text-zinc-300">
+											{t("projects.state.emptyDescription")}
+										</CardDescription>
+									</CardHeader>
+								</Card>
+							</div>
+						)}
+
+						{!isLoading && !isError && repos.length > 0 && (
+							<AnimatePresence>
+								{repos.map((repo) => (
+									<motion.div
+										key={repo.id}
+										initial={{ opacity: 0, y: 20 }}
+										animate={{ opacity: 1, y: 0 }}
+										exit={{ opacity: 0, y: 20 }}
+										transition={{ duration: 0.35 }}
+									>
+										<Card className="group relative h-full overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-b from-white/10 via-slate-950/60 to-black/80 p-0 text-white shadow-2xl shadow-black/40 before:absolute before:-right-12 before:top-0 before:h-48 before:w-48 before:rounded-full before:bg-blue-500/30 before:blur-3xl before:transition before:duration-500 before:content-[''] after:absolute after:-bottom-12 after:-left-12 after:h-48 after:w-48 after:rounded-full after:bg-emerald-400/20 after:blur-3xl after:content-[''] hover:before:scale-110">
+											<CardHeader className="relative space-y-4 px-6 py-2">
+												<div className="flex flex-wrap items-center gap-3 text-xs uppercase">
+													<Badge className="border border-blue-500/40 bg-blue-500/10 px-3 py-1 text-[0.65rem] tracking-[0.25rem] text-blue-200">
+														{repo.language ??
+															t(
+																"projects.languageFallback",
+															)}
+													</Badge>
+												</div>
+												<CardTitle className="text-2xl font-semibold">
+													{repo.name}
+												</CardTitle>
+												<CardDescription className="line-clamp-3 text-base text-zinc-300">
+													{repo.description ??
+														t("projects.noDescription")}
+												</CardDescription>
+											</CardHeader>
+											<CardContent className="relative space-y-4 px-6 pb-0 text-sm text-zinc-300">
+												<div className="flex flex-wrap gap-2">
+													{repo.topics
+														?.filter(
+															(topic) =>
+																topic !==
+																"public",
+														)
+														.map((topic) => (
+															<Badge
+																key={topic}
+																variant="outline"
+																className="border-white/20 bg-white/5 text-xs uppercase tracking-[0.2rem] text-white/80"
+															>
+																{topic}
+															</Badge>
+														))}
+												</div>
+											</CardContent>
+											<CardFooter className="relative mt-auto flex gap-3 px-6 pb-6 pt-0">
+												<a
+													href={repo.html_url}
+													target="_blank"
+													className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2rem] text-white transition hover:border-blue-400 hover:text-blue-300"
+												>
+													{t("projects.links.github")}
+													<ArrowUpRight className="size-4" />
+												</a>
+												{repo.homepage && (
+													<a
+														href={repo.homepage}
+														target="_blank"
+														className="inline-flex items-center gap-2 rounded-full border border-emerald-300/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2rem] text-emerald-200 transition hover:border-emerald-300 hover:text-white"
+													>
+														{t("projects.links.website")}
+														<ArrowUpRight className="size-4" />
+													</a>
+												)}
+											</CardFooter>
+										</Card>
+									</motion.div>
+								))}
+							</AnimatePresence>
+						)}
+					</div>
+				</div>
 		</section>
 	);
 };

--- a/src/components/scroll-to-top-button.tsx
+++ b/src/components/scroll-to-top-button.tsx
@@ -52,20 +52,25 @@ const ScrollToTopButton = () => {
 	const progressDegrees = progress * 360;
 
 	return (
-		<div
-			className="fixed bottom-6 right-6 z-50 rounded-full p-[2px] shadow-lg shadow-blue-500/20 transition hover:scale-105"
-			style={{
-				background: `conic-gradient(#3b82f6 ${progressDegrees}deg, rgba(255,255,255,0.15) ${progressDegrees}deg)`,
-			}}
-		>
-			<Button
-				onClick={smoothScrollToTop}
-				className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-900 text-white transition hover:-translate-y-1 cursor-pointer"
-				aria-label="Back to top"
-				size="icon"
+		<div className="fixed bottom-8 right-6 z-50">
+			<div
+				className="relative flex h-16 w-16 items-center justify-center rounded-3xl border border-white/10 bg-slate-950/70 shadow-[0_10px_50px_rgba(23,37,84,0.6)] backdrop-blur transition hover:-translate-y-1"
+				style={{
+					backgroundImage: `conic-gradient(rgba(59,130,246,0.4) ${progressDegrees}deg, rgba(255,255,255,0.1) ${progressDegrees}deg)`,
+				}}
 			>
-				<ArrowUp className="size-5 animate-bounce" />
-			</Button>
+				<Button
+					onClick={smoothScrollToTop}
+					className="group flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900 text-white transition hover:bg-blue-600 cursor-pointer"
+					size="icon"
+					aria-label="Back to top"
+				>
+					<ArrowUp className="size-5 transition group-hover:-translate-y-1" />
+				</Button>
+			</div>
+			<p className="mt-2 text-center text-[0.65rem] font-semibold uppercase tracking-[0.4rem] text-blue-200">
+				Top
+			</p>
 		</div>
 	);
 };

--- a/src/components/techs.tsx
+++ b/src/components/techs.tsx
@@ -6,14 +6,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "./ui/tooltip";
-import {
-	Sheet,
-	SheetContent,
-	SheetDescription,
-	SheetHeader,
-	SheetTitle,
-	SheetTrigger,
-} from "./ui/sheet";
+import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
 import type { ReactNode } from "react";
 import type { Tech } from "../interfaces/tech";
 
@@ -76,46 +69,79 @@ const Techs = () => {
 			<Sheet>
 				<SheetTrigger asChild>{children}</SheetTrigger>
 				<SheetContent
-					side="bottom"
-					className="bg-zinc-900 text-white sm:max-w-2xl"
+					side="right"
+					className="h-full w-full border-l border-white/10 bg-slate-950/90 text-white backdrop-blur-xl sm:max-w-full lg:max-w-3xl lg:rounded-l-[2.5rem]"
 				>
-					<SheetHeader className="border-b border-white/10">
-						<SheetTitle className="text-left text-xl font-bold text-white">
-							{tech.name} · {caseStudy.title}
-						</SheetTitle>
-						<SheetDescription className="text-left text-base text-zinc-300">
-							{caseStudy.summary}
-						</SheetDescription>
-					</SheetHeader>
-					<div className="grid gap-4 px-4 pb-6 pt-4 text-sm text-zinc-100">
-						<div>
-							<p className="text-xs font-bold uppercase tracking-[0.5rem] text-blue-300">
-								{caseLabels.project}
-							</p>
-							<p className="text-base">{caseStudy.project}</p>
-						</div>
-						<div className="grid gap-1 rounded-lg border border-white/10 bg-white/5 p-4 text-sm">
-							<p className="text-xs font-semibold uppercase tracking-[0.4rem] text-emerald-300">
-								{caseLabels.impact}
-							</p>
-							<p className="text-base text-white">
-								{caseStudy.impact}
-							</p>
-						</div>
-						<div className="grid gap-2 lg:grid-cols-2">
-							<div className="rounded-lg border border-white/5 bg-black/30 p-4">
-								<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-purple-300">
-									{caseLabels.metrics}
-								</p>
-								<p className="text-base">{caseStudy.metrics}</p>
+					<div className="flex h-full flex-col overflow-hidden">
+						<div className="flex flex-col gap-4 border-b border-white/10 px-6 py-6 lg:flex-row lg:items-center">
+							<div className="flex items-center gap-4">
+								<span className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
+									<img
+										src={tech.image}
+										alt={tech.name}
+										className="h-10 w-10 object-contain"
+									/>
+								</span>
+								<div>
+									<p className="text-xs uppercase tracking-[0.4rem] text-blue-200">
+										{tech.badge}
+									</p>
+									<h3 className="text-2xl font-bold text-white">
+										{tech.name}
+									</h3>
+									<p className="text-sm text-zinc-400">
+										{caseStudy.title}
+									</p>
+								</div>
 							</div>
-							<div className="rounded-lg border border-white/5 bg-black/30 p-4">
-								<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-amber-200">
-									{caseLabels.timeframe}
+							<div className="border-t border-white/10 pt-4 text-sm text-zinc-300 lg:ml-auto lg:border-none lg:pt-0">
+								<p className="text-xs font-semibold uppercase tracking-[0.4rem] text-blue-300">
+									{caseLabels.project}
 								</p>
-								<p className="text-base">
-									{caseStudy.timeframe}
+								<p className="text-base text-white">
+									{caseStudy.project}
 								</p>
+							</div>
+						</div>
+
+						<div className="flex-1 overflow-y-auto px-6 py-6">
+							<div className="space-y-5 text-sm text-zinc-100">
+								<div className="space-y-2 rounded-[2rem] border border-white/10 bg-white/5 p-5">
+									<p className="text-xs font-semibold uppercase tracking-[0.4rem] text-blue-200">
+										{caseLabels.summary}
+									</p>
+									<p className="text-base text-white">
+										{caseStudy.summary}
+									</p>
+								</div>
+
+								<div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-emerald-500/15 via-slate-950/40 to-blue-500/20 p-5">
+									<p className="text-xs font-semibold uppercase tracking-[0.4rem] text-emerald-200">
+										{caseLabels.impact}
+									</p>
+									<p className="mt-2 text-base text-white">
+										{caseStudy.impact}
+									</p>
+								</div>
+
+								<div className="grid gap-4 md:grid-cols-2">
+									<div className="rounded-2xl border border-white/10 bg-black/30 p-5">
+										<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-purple-300">
+											{caseLabels.metrics}
+										</p>
+										<p className="mt-2 text-lg text-white">
+											{caseStudy.metrics}
+										</p>
+									</div>
+									<div className="rounded-2xl border border-white/10 bg-black/30 p-5">
+										<p className="text-xs font-semibold uppercase tracking-[0.3rem] text-amber-200">
+											{caseLabels.timeframe}
+										</p>
+										<p className="mt-2 text-lg text-white">
+											{caseStudy.timeframe}
+										</p>
+									</div>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -127,10 +153,25 @@ const Techs = () => {
 	return (
 		<TooltipProvider>
 			<section
-				className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-4 py-12"
+				className="relative mx-auto w-full px-4 pb-16 lg:max-w-4xl lg:px-0 xl:max-w-7xl"
 				id="techs"
 			>
-				<div className="grid grid-cols-1 gap-12 lg:grid-cols-3">
+				<div className="pointer-events-none absolute inset-0">
+					<div className="absolute left-0 top-20 h-64 w-64 rounded-full bg-purple-500/15 blur-[140px]" />
+					<div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-blue-400/20 blur-[140px]" />
+				</div>
+				<div className="relative mb-10 space-y-3 text-center">
+					<p className="text-xs font-semibold uppercase tracking-[0.6rem] text-blue-200">
+						{t("techs.kicker")}
+					</p>
+					<h2 className="text-3xl font-bold md:text-4xl">
+						{t("techs.title")}
+					</h2>
+					<p className="text-base text-zinc-300 md:text-lg">
+						{t("techs.subtitle")}
+					</p>
+				</div>
+				<div className="relative grid grid-cols-1 gap-12 lg:grid-cols-3">
 					<div className="grid grid-cols-3 gap-6 lg:col-span-2 lg:grid-cols-4">
 						{featuredTechs.map((tech) => (
 							<Tooltip key={tech.name}>
@@ -138,7 +179,7 @@ const Techs = () => {
 									<TooltipTrigger asChild>
 										<button
 											type="button"
-											className="flex aspect-square w-full items-center justify-center border border-zinc-500 bg-black/30 p-6 transition hover:-translate-y-1 hover:border-blue-400 cursor-pointer"
+											className="flex aspect-square w-full items-center justify-center rounded-2xl border border-white/10 bg-white/5 p-6 text-white transition hover:-translate-y-1 hover:border-blue-400/60 hover:bg-blue-500/5 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 cursor-pointer"
 											aria-label={tech.name}
 										>
 											<img
@@ -155,7 +196,7 @@ const Techs = () => {
 							</Tooltip>
 						))}
 					</div>
-					<div className="grid min-w-full gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-left text-white lg:min-w-80">
+					<div className="relative grid min-w-full gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-left text-white shadow-inner shadow-white/5 lg:min-w-80">
 						<div className="grid grid-cols-[auto_1fr] items-center gap-4 rounded-2xl border border-white/10 bg-black/30 p-5">
 							<h1 className="text-7xl font-extrabold leading-none text-blue-400">
 								{t("techs.stats.years")}
@@ -189,38 +230,38 @@ const Techs = () => {
 						</div>
 					</div>
 				</div>
-				<div className="overflow-hidden rounded-2xl border border-white/10 bg-black/30 px-6 py-5 shadow-lg shadow-black/10">
-					<div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-8">
+				<div className="relative mt-10 overflow-hidden py-5">
+					<div className="flex flex-col gap-4 px-3 lg:flex-row lg:items-center lg:gap-8 lg:px-0">
 						<div className="flex flex-col gap-1 text-sm text-zinc-300">
 							<span className="text-xs font-bold uppercase tracking-[0.6rem] text-blue-300">
 								{t("techs.ticker.label")}
 							</span>
 							<span>{t("techs.ticker.hint")}</span>
 						</div>
-							<div className="relative flex-1 overflow-hidden">
-								<div className="techs-marquee-track flex items-center gap-8">
-									{marqueeTechs.map((tech, index) => (
-										<TechCaseSheet tech={tech} key={`${tech.name}-${index}`}>
-											<button className="flex items-center gap-3 text-left text-lg text-white/90 transition hover:text-white focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 cursor-pointer">
-												<span className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5">
-													<img
-														src={tech.image}
-														alt={tech.name}
-														className="h-8 w-8 object-contain"
-													/>
+						<div className="relative flex-1 overflow-hidden">
+							<div className="techs-marquee-track flex items-center gap-8">
+								{marqueeTechs.map((tech, index) => (
+									<TechCaseSheet tech={tech} key={`${tech.name}-${index}`}>
+										<button className="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-left text-lg text-white/90 transition hover:-translate-y-0.5 hover:border-blue-400 hover:text-white focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 cursor-pointer">
+											<span className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5">
+												<img
+													src={tech.image}
+													alt={tech.name}
+													className="h-8 w-8 object-contain"
+												/>
+											</span>
+											<div className="flex flex-col">
+												<span className="text-base font-semibold uppercase tracking-wide text-blue-200">
+													{tech.badge}
 												</span>
-												<div className="flex flex-col">
-													<span className="text-base font-semibold uppercase tracking-wide text-blue-200">
-														{tech.badge}
-													</span>
-													<span className="text-lg font-bold">
-														{tech.name}
-													</span>
-												</div>
-											</button>
-										</TechCaseSheet>
-									))}
-								</div>
+												<span className="text-lg font-bold">
+													{tech.name}
+												</span>
+											</div>
+										</button>
+									</TechCaseSheet>
+								))}
+							</div>
 							<div className="pointer-events-none absolute inset-y-0 left-0 w-20 bg-gradient-to-r from-black/70 to-transparent" />
 							<div className="pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-l from-black/70 to-transparent" />
 						</div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex items-center justify-center cursor-pointer gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
 	{
 		variants: {
 			variant: {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -290,6 +290,9 @@
 		]
 	},
 	"techs": {
+		"kicker": "Stack intelligence",
+		"title": "Techs & case studies",
+		"subtitle": "Tools, workflows and the context that proves each stack choice.",
 		"stats": {
 			"years": "+7",
 			"label": "Years of professional experience"
@@ -465,10 +468,13 @@
 		}
 	},
 	"projects": {
+		"kicker": "Code in production",
 		"title": "Projects",
+		"subtitle": "Dashboards, automation pipelines and fullstack experiences focused on measurable outcomes.",
 		"filters": {
 			"all": "All"
 		},
+		"languageFallback": "Multi-stack",
 		"links": {
 			"github": "View on GitHub",
 			"website": "View live"
@@ -527,14 +533,9 @@
 				"href": "https://github.com/M4ciel"
 			},
 			{
-				"id": "medium",
-				"label": "Medium",
-				"href": "https://medium.com/@caiomaciel"
-			},
-			{
-				"id": "certifications",
-				"label": "Certifications",
-				"href": "https://www.credly.com/users/caio-maciel"
+				"id": "linkedin",
+				"label": "LinkedIn",
+				"href": "https://www.linkedin.com/in/caio-maciel"
 			}
 		],
 		"copy": "© {{year}} Caio Maciel. All rights reserved."

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -290,6 +290,9 @@
 		]
 	},
 	"techs": {
+		"kicker": "Stack em produção",
+		"title": "Techs & estudos de caso",
+		"subtitle": "Ferramentas, automações e o contexto que sustenta cada escolha.",
 		"stats": {
 			"years": "+7",
 			"label": "Anos de experiência profissional"
@@ -465,10 +468,13 @@
 		}
 	},
 	"projects": {
+		"kicker": "Código em produção",
 		"title": "Projetos",
+		"subtitle": "Dashboards, automações e experiências fullstack orientadas a resultados mensuráveis.",
 		"filters": {
 			"all": "Todos"
 		},
+		"languageFallback": "Multi-stack",
 		"links": {
 			"github": "Ver no GitHub",
 			"website": "Ver site"
@@ -527,14 +533,9 @@
 				"href": "https://github.com/M4ciel"
 			},
 			{
-				"id": "medium",
-				"label": "Medium",
-				"href": "https://medium.com/@caiomaciel"
-			},
-			{
-				"id": "certifications",
-				"label": "Certificações",
-				"href": "https://www.credly.com/users/caio-maciel"
+				"id": "linkedin",
+				"label": "LinkedIn",
+				"href": "https://www.linkedin.com/in/caio-maciel"
 			}
 		],
 		"copy": "© {{year}} Caio Maciel. Todos os direitos reservados."


### PR DESCRIPTION
## Resumo
- aplica o layout em glassmorphism em hero/sobre/experiências/projetos/techs/contato/footer, com tipografia e fundos luminosos alinhados
- melhora a timeline de experiências (cartões alternados) e o painel de estudos de caso das techs, incluindo títulos/subtítulos e strings traduzidas
- atualiza links do rodapé, botão de “voltar ao topo” e mantém a largura dos blocos consistente; ajusta traduções correspondentes
