### PR TITLE
feat: add data journey signal wave animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import About from "./components/about";
 import Contacts from "./components/contacts";
 import Experience from "./components/experience";
+import DataJourney from "./components/data-journey";
 import Hero from "./components/hero";
 import Projects from "./components/projects";
 import Techs from "./components/techs";
@@ -19,6 +20,7 @@ function App() {
 				<Hero />
 				<About />
 				<Experience />
+				<DataJourney />
 				<Techs />
 				<Projects />
 				<Contacts />

--- a/src/components/data-journey.tsx
+++ b/src/components/data-journey.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Badge } from "./ui/badge";
+import { CircuitBoard } from "lucide-react";
+
+type StageBlock = {
+	id: string;
+	title: string;
+	description: string;
+	signal: string;
+	badge: string;
+};
+
+type ToolCard = {
+	id: string;
+	title: string;
+	role: string;
+	pillar: string;
+	description: string;
+	outcome: string;
+	tags: string[];
+};
+
+type LegendContent = {
+	title: string;
+	hint: string;
+};
+
+const shapeArray = <T,>(value: T[] | Record<string, T> | undefined) => {
+	if (!value) return [];
+	return Array.isArray(value) ? value : Object.values(value);
+};
+
+const SIGNAL_POINTS = 8;
+
+const DataJourney = () => {
+	const { t } = useTranslation();
+	const [hoveredStage, setHoveredStage] = useState<number | null>(null);
+	const legend = t("dataJourney.legend", {
+		returnObjects: true,
+	}) as LegendContent;
+	const stagesTranslation = t("dataJourney.stages", {
+		returnObjects: true,
+	}) as StageBlock[] | Record<string, StageBlock>;
+	const stages = shapeArray<StageBlock>(stagesTranslation);
+	const toolsTranslation = t("dataJourney.tools", {
+		returnObjects: true,
+	}) as ToolCard[] | Record<string, ToolCard>;
+	const tools = shapeArray<ToolCard>(toolsTranslation);
+
+	return (
+		<section
+			className="relative mx-auto w-full px-4 pb-16 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
+			id="data-journey"
+		>
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute left-6 top-10 h-72 w-72 rounded-full bg-cyan-400/10 blur-[140px]" />
+				<div className="absolute bottom-10 right-10 h-72 w-72 rounded-full bg-purple-500/10 blur-[140px]" />
+			</div>
+			<div className="relative space-y-4 text-center">
+				<p className="text-xs font-semibold uppercase tracking-[0.6rem] text-blue-200">
+					{t("dataJourney.kicker")}
+				</p>
+				<h2 className="text-3xl font-bold md:text-4xl">
+					{t("dataJourney.title")}
+				</h2>
+				<p className="text-base text-zinc-300 md:text-lg">
+					{t("dataJourney.subtitle")}
+				</p>
+			</div>
+
+			<div className="relative mt-12 grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+				<article className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900/70 to-blue-900/30 p-6 shadow-2xl shadow-black/40 md:p-8">
+					<div className="pointer-events-none absolute inset-0 opacity-70">
+						<div className="absolute inset-0 bg-[radial-gradient(circle,_rgba(59,130,246,0.18)_1px,transparent_1px)] bg-[size:20px_20px]" />
+					</div>
+					<div className="relative flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-5 py-3 text-left text-white shadow-inner shadow-white/5">
+						<CircuitBoard className="size-10 text-cyan-300" />
+						<div>
+							<p className="text-xs uppercase tracking-[0.4rem] text-blue-200">
+								{legend.title}
+							</p>
+							<p className="text-sm text-zinc-200">{legend.hint}</p>
+						</div>
+					</div>
+
+					<div className="mt-8 space-y-12">
+						{stages.map((stage, index) => {
+							const isLast = index === stages.length - 1;
+							const connectorIndex = index;
+							const isConnectorActive =
+								hoveredStage !== null &&
+								(connectorIndex === hoveredStage ||
+									connectorIndex === hoveredStage - 1);
+							const signalOpacity = isConnectorActive ? 1 : 0.3;
+							const signalDuration = isConnectorActive ? 0.5 : 2;
+							return (
+								<div
+									key={stage.id}
+									className="stage-stack flex flex-col items-center gap-6"
+									onMouseEnter={() => setHoveredStage(index)}
+									onMouseLeave={() => setHoveredStage(null)}
+								>
+									<div className="stage-card relative overflow-hidden rounded-[2.25rem] border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-300/60 hover:bg-white/10 md:p-7">
+										<div className="stage-card__glow" aria-hidden />
+										<div className="flex flex-wrap items-center gap-4">
+											<div className="stage-card__step">
+												<span className="stage-card__step-number">
+													{String(index + 1).padStart(2, "0")}
+												</span>
+												<span className="stage-card__step-dot" />
+											</div>
+											<div className="space-y-1 text-left">
+												<p className="text-[0.65rem] uppercase tracking-[0.6rem] text-sky-200">
+													{stage.title}
+												</p>
+												<h3 className="text-2xl font-semibold text-white">
+													{stage.badge}
+												</h3>
+											</div>
+										</div>
+										<div className="mt-5">
+											<Badge className="stage-card__signal">
+												{stage.signal}
+											</Badge>
+										</div>
+										<p className="mt-4 text-base text-zinc-200">
+											{stage.description}
+										</p>
+									</div>
+									{!isLast && (
+										<div
+											className="signal-connector flex flex-col items-center justify-center text-cyan-300"
+											aria-hidden
+										>
+											<span className="signal-connector-line">
+												{Array.from({ length: SIGNAL_POINTS }).map(
+													(_, dotIndex) => (
+														<span
+															key={`${stage.id}-dot-${dotIndex}`}
+															className="signal-dot"
+															style={{
+																top: `${(dotIndex / (SIGNAL_POINTS - 1)) * 100}%`,
+																animationDelay: `${dotIndex * 0.15}s`,
+																animationDuration: `${signalDuration}s`,
+																opacity: signalOpacity,
+															}}
+														/>
+													),
+												)}
+											</span>
+										</div>
+									)}
+								</div>
+							);
+						})}
+					</div>
+				</article>
+
+				<div className="space-y-4">
+					{tools.map((tool) => (
+						<article
+							key={tool.id}
+							className="rounded-[2rem] border border-white/10 bg-white/5 p-5 shadow-lg shadow-black/20 transition hover:-translate-y-1 hover:border-purple-300/60 hover:bg-white/10"
+						>
+							<div className="flex flex-col gap-3">
+								<div className="flex items-center justify-between gap-2">
+									<div>
+										<p className="text-[0.65rem] font-semibold uppercase tracking-[0.4rem] text-purple-200">
+											{tool.role}
+										</p>
+										<h3 className="text-2xl font-semibold text-white">
+											{tool.title}
+										</h3>
+									</div>
+									<Badge className="border border-white/20 bg-white/10 text-xs text-zinc-100">
+										{tool.pillar}
+									</Badge>
+								</div>
+								<p className="text-sm text-zinc-200">{tool.description}</p>
+								<p className="text-sm font-semibold text-emerald-300">
+									{tool.outcome}
+								</p>
+							</div>
+							<div className="mt-4 flex flex-wrap gap-2">
+								{tool.tags.map((tag) => (
+									<Badge
+										key={`${tool.id}-${tag}`}
+										variant="outline"
+										className="border-white/20 bg-transparent text-[0.65rem] uppercase tracking-[0.2rem] text-zinc-200"
+									>
+										{tag}
+									</Badge>
+								))}
+							</div>
+						</article>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+};
+
+export default DataJourney;

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -72,7 +72,6 @@ const Experience = () => {
 			parseDate(a.period.start).getTime()
 		);
 	});
-
 	return (
 		<section
 			className="relative mx-auto w-full px-4 pb-16 text-white lg:max-w-4xl lg:px-0 xl:max-w-7xl"
@@ -93,7 +92,6 @@ const Experience = () => {
 					{t("experience.subtitle")}
 				</p>
 			</div>
-
 			<div className="relative mt-12">
 				<span
 					aria-hidden

--- a/src/index.css
+++ b/src/index.css
@@ -143,3 +143,173 @@ html {
 		transform: translateX(-50%);
 	}
 }
+
+.signal-flow {
+	position: absolute;
+	inset: 0.35rem;
+	border-radius: 1.5rem;
+	opacity: 0;
+	overflow: hidden;
+	background: linear-gradient(
+		120deg,
+		rgba(14, 165, 233, 0.05),
+		rgba(59, 130, 246, 0.12),
+		rgba(16, 185, 129, 0.08)
+	);
+	transition: opacity 0.3s ease;
+}
+
+.group:hover .signal-flow {
+	opacity: 1;
+}
+
+.signal-flow::after {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: -100%;
+	width: 220%;
+	height: 100%;
+	background: linear-gradient(
+		90deg,
+		transparent,
+		rgba(14, 165, 233, 0.4),
+		rgba(34, 197, 94, 0.55),
+		transparent
+	);
+	animation: signalSweep 3.2s linear infinite;
+}
+
+.signal-connector-line {
+	display: block;
+	width: 3px;
+	height: 4.25rem;
+	border-radius: 999px;
+	background: linear-gradient(
+		180deg,
+		rgba(14, 165, 233, 0),
+		rgba(59, 130, 246, 0.35),
+		rgba(16, 185, 129, 0.45),
+		rgba(236, 72, 153, 0)
+	);
+	position: relative;
+	overflow: hidden;
+}
+
+.signal-dot {
+	position: absolute;
+	left: 50%;
+	width: 0.45rem;
+	height: 0.45rem;
+	border-radius: 999px;
+	transform: translate(-50%, -50%);
+	background: radial-gradient(circle, rgba(125, 211, 252, 0.9), rgba(6, 182, 212, 0.15));
+	box-shadow: 0 0 8px rgba(6, 182, 212, 0.6);
+	animation: signalWave 1.4s ease-in-out infinite;
+	opacity: 0.5;
+}
+
+@keyframes signalSweep {
+	0% {
+		transform: translateX(-10%);
+		opacity: 0;
+	}
+	20% {
+		opacity: 1;
+	}
+	80% {
+		opacity: 1;
+	}
+	100% {
+		transform: translateX(10%);
+		opacity: 0;
+	}
+}
+
+.stage-card {
+	background: linear-gradient(145deg, rgba(7, 16, 36, 0.95), rgba(8, 47, 73, 0.7));
+	box-shadow:
+		0 20px 50px rgba(15, 23, 42, 0.6),
+		inset 0 0 0 1px rgba(94, 234, 212, 0.05);
+	position: relative;
+	z-index: 2;
+}
+
+.stage-stack {
+	position: relative;
+	z-index: 1;
+}
+
+.signal-connector {
+	z-index: 5;
+	height: 4.25rem;
+}
+
+.stage-card__glow {
+	position: absolute;
+	inset: 0;
+	border-radius: 2.25rem;
+	background: radial-gradient(
+			150% 120% at 90% 0%,
+			rgba(59, 130, 246, 0.15),
+			transparent
+		),
+		radial-gradient(120% 120% at 0% 0%, rgba(16, 185, 129, 0.15), transparent);
+	opacity: 0;
+	transition: opacity 0.4s ease;
+}
+
+.stage-card:hover .stage-card__glow,
+.stage-card:focus-visible .stage-card__glow {
+	opacity: 1;
+}
+
+.stage-card__step {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.4rem;
+}
+
+.stage-card__step-number {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 3rem;
+	height: 3rem;
+	border-radius: 999px;
+	background: radial-gradient(circle, rgba(15, 23, 42, 0.9), rgba(3, 7, 18, 0.9));
+	border: 1px solid rgba(59, 130, 246, 0.35);
+	font-weight: 600;
+	color: rgba(191, 219, 254, 1);
+	font-size: 0.95rem;
+}
+
+.stage-card__step-dot {
+	width: 0.4rem;
+	height: 0.4rem;
+	border-radius: 999px;
+	background: rgba(56, 189, 248, 0.8);
+	box-shadow: 0 0 12px rgba(56, 189, 248, 0.9);
+}
+
+.stage-card__signal {
+	border-radius: 999px;
+	border-color: rgba(16, 185, 129, 0.3);
+	background: rgba(16, 185, 129, 0.12);
+	color: #d1fae5;
+	letter-spacing: 0.35rem;
+}
+
+@keyframes signalWave {
+	0%,
+	100% {
+		transform: translate(-50%, -50%) scale(1);
+		opacity: 0.6;
+	}
+	50% {
+		transform: translate(-50%, -50%) scale(2);
+		opacity: 1;
+		box-shadow: 0 0 20px rgba(56, 189, 248, 0.8);
+	}
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -289,6 +289,76 @@
 			}
 		]
 	},
+	"dataJourney": {
+		"kicker": "Modern Data Stack",
+		"title": "Interactive roadmap from ingestion to analytics",
+		"subtitle": "A canvas that shows how the stack flows in production when I mix Airbyte, Airflow, dbt and BigQuery for clients.",
+		"legend": {
+			"title": "Live canvas",
+			"hint": "Hover each block to see how the signals travel from ingestion to analytics."
+		},
+		"stages": [
+			{
+				"id": "ingestion",
+				"title": "Ingestion",
+				"description": "Airbyte connectors ingest SaaS, OLTP and event streams while Airflow guarantees retries, secrets management and observability.",
+				"signal": "1M+ rows/hour with replay-safe jobs.",
+				"badge": "Airbyte + Airflow"
+			},
+			{
+				"id": "transformation",
+				"title": "Transformation",
+				"description": "dbt builds the semantic layer with contracts, tests and slim CI before tables land in curated marts.",
+				"signal": "180+ models versioned and documented.",
+				"badge": "dbt core"
+			},
+			{
+				"id": "analytics",
+				"title": "Analytics & serving",
+				"description": "BigQuery warehouses power dashboards, AI apps and reverse ETL pushing the insights back to business tools.",
+				"signal": "Sub-90s freshness for decision makers.",
+				"badge": "BigQuery"
+			}
+		],
+		"tools": [
+			{
+				"id": "airflow",
+				"title": "Apache Airflow",
+				"role": "Orchestration",
+				"pillar": "Governance-first DAG factory",
+				"description": "Designed factory patterns, versioned DAGs and SLA monitors so squads plug-in new connectors without rewriting boilerplate.",
+				"outcome": "Reduced ingestion lead time and removed pager fatigue by centralizing alerting plus retries.",
+				"tags": ["Dynamic DAGs", "Data contracts", "Observability"]
+			},
+			{
+				"id": "airbyte",
+				"title": "Airbyte",
+				"role": "Connectors",
+				"pillar": "Source catalog & CDC",
+				"description": "Curated connectors spanning SaaS CRMs, payment providers and PostgreSQL replicas with incremental merges and dead-letter lanes.",
+				"outcome": "New sources go live within days, keeping business units tied to a governed ingestion path.",
+				"tags": ["CDC", "SaaS ingest", "Quality gates"]
+			},
+			{
+				"id": "dbt",
+				"title": "dbt",
+				"role": "Semantic layer",
+				"pillar": "Analytics engineering rituals",
+				"description": "Applied contracts, exposures, data tests and lineage docs so analysts trust the same curated marts across squads.",
+				"outcome": "Accelerated discovery while cutting storage costs by pruning unused tables and snapshots.",
+				"tags": ["Contracts", "Testing", "Slim CI"]
+			},
+			{
+				"id": "bigquery",
+				"title": "BigQuery",
+				"role": "Warehouse",
+				"pillar": "Serving and governance",
+				"description": "Partitioning, clustering and row-level security keep the warehouse cost-efficient and compliant for fintech workloads.",
+				"outcome": "Analytics, ML notebooks and reverse ETL jobs share the same trusted warehouse without conflicts.",
+				"tags": ["Serving", "Security", "Cost control"]
+			}
+		]
+	},
 	"techs": {
 		"kicker": "Stack intelligence",
 		"title": "Techs & case studies",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -289,6 +289,76 @@
 			}
 		]
 	},
+	"dataJourney": {
+		"kicker": "Modern Data Stack",
+		"title": "Roadmap interativo da ingestão ao analytics",
+		"subtitle": "Um canvas que mostra como conecto Airbyte, Airflow, dbt e BigQuery em produção para clientes reais.",
+		"legend": {
+			"title": "Canvas vivo",
+			"hint": "Passe o mouse em cada bloco e veja os sinais atravessando ingestão, transformação e analytics."
+		},
+		"stages": [
+			{
+				"id": "ingestion",
+				"title": "Ingestão",
+				"description": "Conectores Airbyte ingerem SaaS, OLTP e streams enquanto o Airflow garante retries, gestão de segredos e observabilidade.",
+				"signal": "1M+ linhas/hora com reprocessamento seguro.",
+				"badge": "Airbyte + Airflow"
+			},
+			{
+				"id": "transformation",
+				"title": "Transformação",
+				"description": "dbt constrói a camada semântica com contratos, testes e slim CI antes de publicar as tabelas em marts curados.",
+				"signal": "180+ modelos versionados e documentados.",
+				"badge": "dbt core"
+			},
+			{
+				"id": "analytics",
+				"title": "Analytics & serving",
+				"description": "BigQuery alimenta dashboards, apps de IA e reverse ETL devolvendo os insights aos sistemas de negócios.",
+				"signal": "Freshness abaixo de 90s para líderes.",
+				"badge": "BigQuery"
+			}
+		],
+		"tools": [
+			{
+				"id": "airflow",
+				"title": "Apache Airflow",
+				"role": "Orquestração",
+				"pillar": "Fábrica de DAGs com governança",
+				"description": "Desenhei patterns reaproveitáveis, versionamento e monitores de SLA para squads plugarem novos conectores sem boilerplate.",
+				"outcome": "Reduzi o lead time de ingestão e o desgaste de plantão centralizando alertas e retries inteligentes.",
+				"tags": ["DAGs dinâmicas", "Data contracts", "Observabilidade"]
+			},
+			{
+				"id": "airbyte",
+				"title": "Airbyte",
+				"role": "Conectores",
+				"pillar": "Catálogo de fontes & CDC",
+				"description": "Cuidei de conectores para CRMs SaaS, meios de pagamento e réplicas PostgreSQL com merges incrementais e pistas de rejeição.",
+				"outcome": "Novas fontes entram em produção em poucos dias e seguem o mesmo trilho governado.",
+				"tags": ["CDC", "Ingest SaaS", "Quality gates"]
+			},
+			{
+				"id": "dbt",
+				"title": "dbt",
+				"role": "Camada semântica",
+				"pillar": "Rituais de analytics engineering",
+				"description": "Apliquei contratos, exposures, testes e lineage para que analistas confiem nos mesmos marts curados entre squads.",
+				"outcome": "Descoberta mais rápida e custos menores ao limpar tabelas e snapshots sem uso.",
+				"tags": ["Contratos", "Testes", "Slim CI"]
+			},
+			{
+				"id": "bigquery",
+				"title": "BigQuery",
+				"role": "Data warehouse",
+				"pillar": "Servir e governar",
+				"description": "Particionamento, clustering e políticas linha-a-linha deixam o warehouse eficiente e em conformidade com workloads fintech.",
+				"outcome": "Analytics, notebooks de ML e reverse ETL compartilham o mesmo repositório sem conflitos.",
+				"tags": ["Servir", "Segurança", "Controle de custos"]
+			}
+		]
+	},
 	"techs": {
 		"kicker": "Stack em produção",
 		"title": "Techs & estudos de caso",


### PR DESCRIPTION
### Resumo

- adicionei a seção `DataJourney` ao portfólio, trazendo o canvas do Modern Data Stack com estágios (ingestão → transformação → analytics) e cards detalhando Airbyte, Airflow, dbt e BigQuery com textos localizados em PT/EN.
- criei o componente `src/components/data-journey.tsx` com o canvas, legendas, cards e o conector animado entre os blocos usando oito pontos (sinais) que simulam o fluxo de dados.
- integrei a nova seção na `App.tsx` logo após a timeline de experiência para reforçar o study case.
- ajustei estilos globais (`src/index.css`) para suportar o gradiente dos cards, a animação das bolinhas e o efeito de hover que acelera/destaca o sinal.
- atualizei as traduções (`src/locales/en/common.json` e `src/locales/pt/common.json`) com os textos do roadmap (kicker, título, legend, stages e tool cards).
- limpei `components/experience.tsx` de métricas que já não eram necessárias, preparando o espaço para o novo painel.